### PR TITLE
Add org-wide coding hours workflow

### DIFF
--- a/.github/scripts/org_coding_hours.py
+++ b/.github/scripts/org_coding_hours.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import json, os, pathlib, subprocess, tempfile, datetime, sys
+
+REPOS = os.getenv("REPOS", "").split()
+SINCE = os.getenv("WINDOW_START", "")
+
+if not REPOS:
+    sys.exit("REPOS env var must list repositories to process")
+
+def run_git_hours(repo: str) -> dict:
+    temp = tempfile.mkdtemp()
+    subprocess.run(["git", "clone", "--depth", "1", f"https://github.com/{repo}.git", temp], check=True)
+    cmd = ["git-hours", "--json"]
+    if SINCE:
+        cmd.extend(["-since", SINCE])
+    out = subprocess.check_output(cmd, cwd=temp, text=True)
+    return json.loads(out)
+
+def aggregate(results: list[dict]) -> dict:
+    agg = {"total": {"hours": 0, "commits": 0}}
+    for data in results:
+        for email, rec in data.items():
+            if email == "total":
+                continue
+            entry = agg.setdefault(email, {"hours": 0, "commits": 0})
+            entry["hours"] += rec["hours"]
+            entry["commits"] += rec["commits"]
+            agg["total"]["hours"] += rec["hours"]
+            agg["total"]["commits"] += rec["commits"]
+    return agg
+
+def main():
+    results = {}
+    for repo in REPOS:
+        print(f"Processing {repo}")
+        results[repo] = run_git_hours(repo)
+    agg = aggregate(list(results.values()))
+    date = datetime.date.today().isoformat()
+    reports = pathlib.Path("reports")
+    reports.mkdir(exist_ok=True)
+    for repo, data in results.items():
+        name = repo.replace('/', '_')
+        (reports / f"git-hours-{name}-{date}.json").write_text(json.dumps(data, indent=2))
+    (reports / f"git-hours-aggregated-{date}.json").write_text(json.dumps(agg, indent=2))
+    print(json.dumps(agg, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -1,0 +1,55 @@
+name: Org Coding Hours
+
+on:
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: 'Space-separated list of owner/repo names'
+        required: true
+      window_start:
+        description: 'Optional start date YYYY-MM-DD'
+        required: false
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with: { go-version: '1.24' }
+    - name: Install git-hours v0.1.2
+      run: |
+        git clone --depth 1 --branch v0.1.2 https://github.com/trinhminhtriet/git-hours.git git-hours-src
+        sed -i 's/go 1.24.1/go 1.24/' git-hours-src/go.mod
+        (cd git-hours-src && go install .)
+    - name: Run git-hours across repos
+      env:
+        REPOS: ${{ github.event.inputs.repos }}
+        WINDOW_START: ${{ github.event.inputs.window_start }}
+      run: |
+        python .github/scripts/org_coding_hours.py
+    - name: Push reports to metrics branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config --global user.name  "git-hours bot"
+        git config --global user.email "bot@github.com"
+        git stash push --include-untracked --quiet
+        git fetch origin metrics || true
+        if git show-ref --quiet refs/remotes/origin/metrics; then
+          git switch --quiet metrics || git switch -c metrics origin/metrics
+          git pull --ff-only origin metrics || true
+        else
+          git switch --orphan metrics
+          git reset --hard
+        fi
+        git stash pop --quiet || true
+        git add reports
+        git commit -m "chore(metrics): org report $(date +%F)" || echo "No change"
+        git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics \
+        || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics


### PR DESCRIPTION
## Summary
- add `org_coding_hours.py` helper script to aggregate git-hours across multiple repositories
- create `org-coding-hours.yml` workflow that runs the script and pushes reports to the metrics branch

## Testing
- `python -m py_compile .github/scripts/org_coding_hours.py`

------
https://chatgpt.com/codex/tasks/task_e_688a9b27209c8329b6ee209c022cc957