### PR TITLE
Fix contact typo in README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - 🌱 [Feature & Experiment Workflows](#feature--experiment-workflows)  
 - 📚 [Documentation](#documentation)  
 - 📄 [License & CLA](#license--cla)  
-- 💬 [Contarct & Discord](#contact--discord)
+- 💬 [Contact & Discord](#contact--discord)
 
 ---
 


### PR DESCRIPTION
## Summary
- fix a typo in the README table of contents

## Testing
- `grep -n Contact README.md`

------
https://chatgpt.com/codex/tasks/task_e_688acdc3af788329a3180129621d8dfd