### PR TITLE
Add repo dropdown to coding-hours workflow

### DIFF
--- a/.github/workflows/coding-hours.yml
+++ b/.github/workflows/coding-hours.yml
@@ -5,6 +5,15 @@ on:
     - cron: '0 0 * * 1'                 # every Monday 00:00 UTC
   workflow_dispatch:
     inputs:
+      repo:
+        description: 'Repository owner/name'
+        required: true
+        type: choice
+        default: ni/labview-icon-editor
+        options:
+          - ni/labview-icon-editor
+          - ni/actor-framework
+          - ni/open-source
       window_start:
         description: 'Report since YYYY‑MM‑DD'
         required: false
@@ -24,7 +33,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with: { fetch-depth: 0 }
+      with:
+        repository: ${{ github.event.inputs.repo || github.repository }}
+        fetch-depth: 0
 
     - uses: actions/setup-go@v4
       with: { go-version: '1.24' }
@@ -116,6 +127,7 @@ jobs:
     - name: Push to metrics branch
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TARGET_REPO: ${{ github.event.inputs.repo || github.repository }}
       run: |
         git config --global user.name  "git-hours bot"
         git config --global user.email "bot@github.com"
@@ -141,8 +153,8 @@ jobs:
         git add reports badge.json
         git commit -m "chore(metrics): report $(date +%F)" || echo "No change"
 
-        git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics \
-        || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics
+        git push https://x-access-token:${GITHUB_TOKEN}@github.com/${TARGET_REPO} metrics \
+        || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${TARGET_REPO} metrics
 
 
 ###############################################################################
@@ -154,6 +166,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.inputs.repo || github.repository }}
 
     - uses: actions/download-artifact@v4
       with: { name: git-hours-json, path: tmp }


### PR DESCRIPTION
## Summary
- allow user to choose which repo to analyze in `coding-hours.yml`

## Testing
- `yamllint .github/workflows/coding-hours.yml` *(fails: wrong indentation, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688ad6d102c08329a50ea4249f50cf9e