### PR TITLE
Support multi-repo hours report

### DIFF
--- a/.github/workflows/coding-hours.yml
+++ b/.github/workflows/coding-hours.yml
@@ -5,15 +5,10 @@ on:
     - cron: '0 0 * * 1'                 # every Monday 00:00 UTC
   workflow_dispatch:
     inputs:
-      repo:
-        description: 'Repository to analyze'
+      repos:
+        description: 'Space-separated list of owner/repo names'
         required: true
-        type: choice
-        options:
-          - ni/labview-icon-editor
-          - ni/actor-framework
-          - ni/open-source
-        default: ni/labview-icon-editor
+        default: 'ni/actor-framework ni/labview-icon-editor ni/open-source'
       window_start:
         description: 'Report since YYYY‑MM‑DD'
         required: false
@@ -30,11 +25,12 @@ jobs:
   report:
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    env:
+      REPOS: ${{ github.event.inputs.repos || 'ni/actor-framework ni/labview-icon-editor ni/open-source' }}
 
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: ${{ github.event.inputs.repo }}
         fetch-depth: 0
 
     - uses: actions/setup-go@v4
@@ -48,57 +44,20 @@ jobs:
         # v0.1.2 has no --version flag; show help header instead
         git-hours -h | head -n 1
 
-    - name: Generate raw report
+    - name: Run git-hours across repos
+      env:
+        REPOS: ${{ env.REPOS }}
+        WINDOW_START: ${{ github.event.inputs.window_start }}
       run: |
-        ARGS=""
-        if [ -n "${{ github.event.inputs.window_start }}" ]; then
-          ARGS+=" -since ${{ github.event.inputs.window_start }}"
-        fi
-        git-hours $ARGS > raw.txt
-        cat raw.txt
-
-    # ──────────────────────────── PATCH ① auto‑detect JSON vs table ──
-    - name: Convert to JSON
-      run: |
-        python - <<'PY'
-        import json, re, pathlib
-        raw_text = pathlib.Path('raw.txt').read_text().lstrip()
-
-        def table_to_json(lines):
-            obj, th, tc = {}, 0, 0
-            for line in lines:
-                if not line or line.lower().startswith(('author','name','user','----','total')):
-                    continue
-                parts = re.split(r'\s+', line.strip())
-                if len(parts) < 3:
-                    continue
-                commits = int(parts[-1])
-                hours   = int(parts[-2])
-                email   = ' '.join(parts[:-2])
-                obj[email] = {"name": email, "hours": hours, "commits": commits}
-                th += hours; tc += commits
-            obj["total"] = {"name":"", "hours": th, "commits": tc}
-            return obj
-
-        try:                                   # already JSON?
-            data = json.loads(raw_text)
-            if "total" not in data:
-                th = sum(v["hours"] for v in data.values())
-                tc = sum(v["commits"] for v in data.values())
-                data["total"] = {"name":"", "hours": th, "commits": tc}
-        except json.JSONDecodeError:
-            data = table_to_json(raw_text.splitlines())
-
-        pathlib.Path('git-hours.json').write_text(json.dumps(data, indent=2))
-        PY
-      # ────────────────────────────────────────────────────────────────
+        python .github/scripts/org_coding_hours.py
 
     - name: Install jq
       run: sudo apt-get update -y && sudo apt-get install -y jq
 
     - name: Build badge.json
       run: |
-        HOURS=$(jq '.total.hours' git-hours.json)
+        AGG=$(ls reports/git-hours-aggregated-*.json | head -n1)
+        HOURS=$(jq '.total.hours' "$AGG")
         cat > badge.json <<EOF
         { "schemaVersion":1,
           "label":"Coding hours",
@@ -108,6 +67,7 @@ jobs:
 
     - name: Add workflow summary
       run: |
+        AGG=$(ls reports/git-hours-aggregated-*.json | head -n1)
         echo "### ⏱ Coding‑hours report" >> "$GITHUB_STEP_SUMMARY"
         jq -r '
           to_entries
@@ -115,12 +75,12 @@ jobs:
           | sort_by(-.value.hours)
           | (["Contributor","Hours","Commits"]
              , (map([.key, (.value.hours|tostring), (.value.commits|tostring)])))
-          | @tsv' git-hours.json | column -t -s $'\t' >> "$GITHUB_STEP_SUMMARY"
+          | @tsv' "$AGG" | column -t -s $'\t' >> "$GITHUB_STEP_SUMMARY"
 
     - uses: actions/upload-artifact@v4
       with:
         name: git-hours-json
-        path: git-hours.json
+        path: reports/*.json
         retention-days: 30
 
     # ──────────────────────────── PATCH ③ safer push logic ───────────
@@ -147,13 +107,11 @@ jobs:
         # Restore stashed badge.json + reports/
         git stash pop --quiet || true
 
-        mkdir -p reports
-        cp git-hours.json "reports/git-hours-$(date +%F).json"
         git add reports badge.json
         git commit -m "chore(metrics): report $(date +%F)" || echo "No change"
 
-        git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.event.inputs.repo }} metrics \
-        || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.event.inputs.repo }} metrics
+        git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics \
+        || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics
 
 
 ###############################################################################
@@ -162,80 +120,94 @@ jobs:
   build-site:
     needs: report
     runs-on: ubuntu-latest
+    env:
+      REPOS: ${{ env.REPOS }}
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        repository: ${{ github.event.inputs.repo }}
 
     - uses: actions/download-artifact@v4
       with: { name: git-hours-json, path: tmp }
 
     - name: Build KPIs site
+      env:
+        REPOS: ${{ env.REPOS }}
       run: |
         DATE=$(date +%F)
         mkdir -p site/data
-        cp tmp/git-hours.json "site/data/git-hours-${DATE}.json"
-        cp tmp/git-hours.json site/git-hours-latest.json
-
-        # (HTML generator unchanged)
+        for f in tmp/*.json; do
+          cp "$f" "site/data/$(basename "$f")"
+          base=$(basename "$f")
+          latest=${base%-${DATE}.json}-latest.json
+          cp "$f" "site/$latest"
+        done
 
         python - <<'PY'
-        import json, datetime, pathlib, html, textwrap
-        data  = json.load(open('tmp/git-hours.json'))
-        total = data['total']
-        labels = [html.escape(k) for k in data if k != 'total']
-        rows = "\n".join(
-            f"<tr><td>{l}</td><td>{data[l]['hours']}</td><td>{data[l]['commits']}</td></tr>"
-            for l in labels)
+        import json, datetime, pathlib, html, textwrap, os, re
+        tmp = pathlib.Path('tmp')
+        files = list(tmp.glob('git-hours-*.json'))
+        repo_map = {r.replace('/', '_'): r for r in os.environ['REPOS'].split()}
+        reports = []
+        for f in files:
+            data = json.load(f.open())
+            name = f.stem
+            if 'aggregated' in name:
+                continue
+            slug = re.sub(r'^git-hours-|-\d{4}-\d{2}-\d{2}$', '', name)
+            reports.append((slug, repo_map.get(slug, slug), data))
 
-        page = f"""
-        <!doctype html><html lang='en'><head>
-          <meta charset='utf-8'>
-          <title>Collaborator KPIs</title>
-          <link rel='stylesheet'
-                href='https://cdn.jsdelivr.net/npm/simpledotcss/simple.min.css'>
-          <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort/sortable.min.js' defer></script>
-          <script src='https://cdn.jsdelivr.net/npm/chart.js'></script>
-          <style>canvas{{max-height:400px}}</style>
-        </head><body><main>
-          <h1>Collaborator KPIs</h1>
-          <p><em>Last updated {datetime.datetime.utcnow():%Y‑%m‑%d %H:%M UTC}</em></p>
-
-          <h2>Totals</h2>
+        page_sections = []
+        for slug, title, data in reports:
+            labels = [html.escape(k) for k in data if k != 'total']
+            rows = "\n".join(
+                f"<tr><td>{l}</td><td>{data[l]['hours']}</td><td>{data[l]['commits']}</td></tr>"
+                for l in labels)
+            total = data['total']
+            page_sections.append(f"""
+          <h2>{title}</h2>
           <ul>
             <li><strong>Hours</strong>: {total['hours']}</li>
             <li><strong>Commits</strong>: {total['commits']}</li>
             <li><strong>Contributors</strong>: {len(data)-1}</li>
           </ul>
-
-          <h2>Hours per contributor</h2>
-          <canvas id='hoursChart'></canvas>
-
-          <h2>Detail table</h2>
+          <canvas id='hoursChart-{slug}'></canvas>
+          <h3>Detail table</h3>
           <table class='sortable'>
             <thead><tr><th>Contributor</th><th>Hours</th><th>Commits</th></tr></thead>
             <tbody>{rows}</tbody>
           </table>
+        """)
 
+        page = f"""
+        <!doctype html><html lang='en'><head>
+          <meta charset='utf-8'>
+          <title>Collaborator KPIs</title>
+          <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/simpledotcss/simple.min.css'>
+          <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort/sortable.min.js' defer></script>
+          <script src='https://cdn.jsdelivr.net/npm/chart.js'></script>
+          <style>canvas{max-height:400px}</style>
+        </head><body><main>
+          <h1>Collaborator KPIs</h1>
+          <p><em>Last updated {datetime.datetime.utcnow():%Y-%m-%d %H:%M UTC}</em></p>
+          {''.join(page_sections)}
           <p>Historical JSON snapshots live in <code>/data</code>.</p>
-
           <script>
-            fetch('git-hours-latest.json')
-              .then(r => r.json())
-              .then(d => {{
-                const labels = Object.keys(d).filter(k => k !== 'total');
-                const hours  = labels.map(l => d[l].hours);
-                new Chart(document.getElementById('hoursChart'), {{
-                  type: 'bar',
-                  data: {{ labels, datasets:[{{label:'Hours',data:hours}}] }},
-                  options: {{
-                    responsive:true, maintainAspectRatio:false,
-                    plugins:{{legend:{{display:false}}}},
-                    scales:{{y:{{beginAtZero:true}}}}
-                  }}
-                }});
-              }});
+            const repos = {json.dumps([slug for slug,_,_ in reports])};
+            repos.forEach(slug => {
+              fetch(`git-hours-${slug}-latest.json`)
+                .then(r => r.json())
+                .then(d => {
+                  const labels = Object.keys(d).filter(k => k !== 'total');
+                  const hours  = labels.map(l => d[l].hours);
+                  new Chart(document.getElementById(`hoursChart-${slug}`), {
+                    type: 'bar',
+                    data: { labels, datasets:[{label:'Hours',data:hours}] },
+                    options: { responsive:true, maintainAspectRatio:false,
+                              plugins:{legend:{display:false}},
+                              scales:{y:{beginAtZero:true}} }
+                  });
+                });
+            });
           </script>
         </main></body></html>
         """


### PR DESCRIPTION
## Summary
- allow selecting multiple repositories for coding-hours report
- run `org_coding_hours.py` to gather reports
- generate chart for each repository

## Testing
- `python -m py_compile .github/scripts/org_coding_hours.py`

------
https://chatgpt.com/codex/tasks/task_e_688ada2a2a688329b9e81e9979b1bd88