### PR TITLE
Remove badge.json from coding-hours workflow

### DIFF
--- a/.github/workflows/coding-hours.yml
+++ b/.github/workflows/coding-hours.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
 ###############################################################################
-# Job 1 – run git‑hours (Go), build badge, commit to `metrics`
+# Job 1 – run git‑hours (Go) and commit to `metrics`
 ###############################################################################
   report:
     if: github.ref == 'refs/heads/develop'
@@ -96,15 +96,6 @@ jobs:
     - name: Install jq
       run: sudo apt-get update -y && sudo apt-get install -y jq
 
-    - name: Build badge.json
-      run: |
-        HOURS=$(jq '.total.hours' git-hours.json)
-        cat > badge.json <<EOF
-        { "schemaVersion":1,
-          "label":"Coding hours",
-          "message":"${HOURS}h",
-          "color":"informational" }
-        EOF
 
     - name: Add workflow summary
       run: |
@@ -145,12 +136,12 @@ jobs:
           git reset --hard
         fi
 
-        # Restore stashed badge.json + reports/
+        # Restore stashed reports/
         git stash pop --quiet || true
 
         mkdir -p reports
         cp git-hours.json "reports/git-hours-$(date +%F).json"
-        git add reports badge.json
+        git add git-hours.json reports
         git commit -m "chore(metrics): report $(date +%F)" || echo "No change"
 
         git push https://x-access-token:${GITHUB_TOKEN}@github.com/${TARGET_REPO} metrics \


### PR DESCRIPTION
## Summary
- drop Build badge.json step from coding-hours workflow
- push only the git-hours JSON and reports directory
- keep artifact upload so later jobs download git-hours.json

## Testing
- `yamllint .github/workflows/coding-hours.yml` *(fails: line-length, indentation, braces)*

------
https://chatgpt.com/codex/tasks/task_e_688ae75de8e483298769c054b3e6fdbf