### PR TITLE
Update docs to describe new coding-hours aggregation

### DIFF
--- a/docs/coding-hours.md
+++ b/docs/coding-hours.md
@@ -6,10 +6,9 @@ This page explains how the repository generates contributor hours and where the 
 
 The **Coding-hours report** workflow runs weekly and can also be triggered manually. It performs the following steps:
 
-1. **Collect statistics** – The job checks out the repository and runs `git-hours` to calculate commit hours per contributor. The results are saved as `git-hours.json` and archived as a workflow artifact.
-2. **Commit to metrics branch** – The JSON report and a `badge.json` file are committed to the `metrics` branch. Historical snapshots are stored under `reports/` in that branch.
-3. **Build the KPIs site** – Using the JSON data, a simple HTML dashboard is generated under a `site/` directory. This directory is then uploaded as a Pages artifact.
-4. **Deploy** – The site artifact is deployed to GitHub Pages so everyone can view the latest dashboard.
+1. **Collect statistics** – The job checks out all three repositories and runs `git-hours` to calculate commit hours per contributor. The aggregated report is saved as `git-hours.json` and archived as a workflow artifact.
+2. **Build the KPIs site** – Using this aggregated data, a simple HTML dashboard is generated under a `site/` directory. This directory is then uploaded as a Pages artifact.
+3. **Deploy** – The site artifact is deployed to GitHub Pages so everyone can view the latest dashboard covering all repositories.
 
 ## Viewing the dashboard
 
@@ -19,8 +18,8 @@ After each successful run, the dashboard is published at:
 https://ni.github.io/labview-icon-editor/
 ```
 
-This page shows the most recent hours per contributor along with historical JSON data.
+This page shows the most recent hours per contributor along with historical JSON data for all repositories.
 
-## Metrics branch and README refresh
+## README refresh
 
-The workflow pushes all reports to the separate `metrics` branch. A second workflow, **Refresh README contributor hours**, watches for completions of the report workflow. It pulls the latest JSON data from the metrics branch and updates the contributor table in `README.md` automatically.
+A second workflow, **Refresh README contributor hours**, watches for completions of the report workflow. It uses the aggregated JSON data to update the contributor table in `README.md` automatically.


### PR DESCRIPTION
## Summary
- document the new weekly workflow that aggregates data from three repos
- remove badge.json and metrics branch references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae9872d788329967d9358e3009615