### PR TITLE
Add org-level coding hours dashboard

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -53,3 +53,97 @@ jobs:
         git commit -m "chore(metrics): org report $(date +%F)" || echo "No change"
         git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics \
         || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: git-hours-aggregated-json
+        path: reports/git-hours-aggregated-*.json
+        retention-days: 30
+
+  build-site:
+    needs: report
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with: { name: git-hours-aggregated-json, path: tmp }
+    - name: Build KPIs site
+      run: |
+        FILE=$(ls tmp/reports/git-hours-aggregated-*.json)
+        DATE=$(date +%F)
+        mkdir -p site/data
+        cp "$FILE" "site/data/git-hours-${DATE}.json"
+        cp "$FILE" site/git-hours-latest.json
+        export FILE
+        python - <<'PY'
+        import json, datetime, pathlib, html, textwrap, os
+        data  = json.load(open(os.environ['FILE']))
+        total = data['total']
+        labels = [html.escape(k) for k in data if k != 'total']
+        rows = "\n".join(
+            f"<tr><td>{l}</td><td>{data[l]['hours']}</td><td>{data[l]['commits']}</td></tr>"
+            for l in labels)
+
+        page = f"""
+        <!doctype html><html lang='en'><head>
+          <meta charset='utf-8'>
+          <title>Collaborator KPIs</title>
+          <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/simpledotcss/simple.min.css'>
+          <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort/sortable.min.js' defer></script>
+          <script src='https://cdn.jsdelivr.net/npm/chart.js'></script>
+          <style>canvas{{max-height:400px}}</style>
+        </head><body><main>
+          <h1>Collaborator KPIs</h1>
+          <p><em>Last updated {datetime.datetime.utcnow():%Y-%m-%d %H:%M UTC}</em></p>
+
+          <h2>Totals</h2>
+          <ul>
+            <li><strong>Hours</strong>: {total['hours']}</li>
+            <li><strong>Commits</strong>: {total['commits']}</li>
+            <li><strong>Contributors</strong>: {len(data)-1}</li>
+          </ul>
+
+          <h2>Hours per contributor</h2>
+          <canvas id='hoursChart'></canvas>
+
+          <h2>Detail table</h2>
+          <table class='sortable'>
+            <thead><tr><th>Contributor</th><th>Hours</th><th>Commits</th></tr></thead>
+            <tbody>{rows}</tbody>
+          </table>
+
+          <p>Historical JSON snapshots live in <code>/data</code>.</p>
+
+          <script>
+            fetch('git-hours-latest.json')
+              .then(r => r.json())
+              .then(d => {
+                const labels = Object.keys(d).filter(k => k !== 'total');
+                const hours  = labels.map(l => d[l].hours);
+                new Chart(document.getElementById('hoursChart'), {
+                  type: 'bar',
+                  data: { labels, datasets:[{label:'Hours',data:hours}] },
+                  options: {
+                    responsive:true, maintainAspectRatio:false,
+                    plugins:{legend:{display:false}},
+                    scales:{y:{beginAtZero:true}}
+                  }
+                });
+              });
+          </script>
+        </main></body></html>
+        """
+        pathlib.Path('site/index.html').write_text(textwrap.dedent(page))
+        PY
+    - uses: actions/upload-pages-artifact@v3
+      with: { path: site }
+
+  deploy-pages:
+    needs: build-site
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- upload aggregated git-hours JSON in org-coding-hours workflow
- build dashboard from aggregated data and deploy Pages

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aebe5f3608329b5cc28c57b4506a8