### PR TITLE
Fix git-hours script for full history

### DIFF
--- a/.github/scripts/org_coding_hours.py
+++ b/.github/scripts/org_coding_hours.py
@@ -10,7 +10,7 @@ if not REPOS:
 def run_git_hours(repo: str) -> dict:
     with tempfile.TemporaryDirectory() as temp:
         subprocess.run(
-            ["git", "clone", "--depth", "1", f"https://github.com/{repo}.git", temp],
+            ["git", "clone", f"https://github.com/{repo}.git", temp],
             check=True,
         )
         cmd = ["git-hours"]


### PR DESCRIPTION
## Summary
- remove shallow clone from org_coding_hours.py so git-hours can run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ae6744c208329a5c95a0d7c94be77