### PR TITLE
Enhance org coding hours workflow design

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -86,6 +86,7 @@ jobs:
         page = f"""
         <!doctype html><html lang='en'><head>
           <meta charset='utf-8'>
+          <meta name='viewport' content='width=device-width, initial-scale=1'>
           <title>Collaborator KPIs</title>
           <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/simpledotcss/simple.min.css'>
           <script src='https://cdn.jsdelivr.net/npm/sortable-tablesort/sortable.min.js' defer></script>
@@ -104,6 +105,8 @@ jobs:
 
           <h2>Hours per contributor</h2>
           <canvas id='hoursChart'></canvas>
+          <h2>Commits per contributor</h2>
+          <canvas id='commitsChart'></canvas>
 
           <h2>Detail table (all repos)</h2>
           <table class='sortable'>
@@ -118,19 +121,29 @@ jobs:
           <script>
             fetch('git-hours-latest.json')
               .then(r => r.json())
-              .then(d => {{
-                const labels = Object.keys(d).filter(k => k !== 'total');
-                const hours  = labels.map(l => d[l].hours);
-                new Chart(document.getElementById('hoursChart'), {{
-                  type: 'bar',
-                  data: {{ labels, datasets:[{{label:'Hours',data:hours}}] }},
-                  options: {{
+              .then(d => {
+                const labels  = Object.keys(d).filter(k => k !== "total");
+                const hours   = labels.map(l => d[l].hours);
+                const commits = labels.map(l => d[l].commits);
+                new Chart(document.getElementById("hoursChart"), {
+                  type: "bar",
+                  data: { labels, datasets:[{label:"Hours",data:hours}] },
+                  options: {
                     responsive:true, maintainAspectRatio:false,
-                    plugins:{{legend:{{display:false}}}},
-                    scales:{{y:{{beginAtZero:true}}}}
-                  }}
-                }});
-              }});
+                    plugins:{legend:{display:false}},
+                    scales:{y:{beginAtZero:true}}
+                  }
+                });
+                new Chart(document.getElementById("commitsChart"), {
+                  type: "bar",
+                  data: { labels, datasets:[{label:"Commits",data:commits}] },
+                  options: {
+                    responsive:true, maintainAspectRatio:false,
+                    plugins:{legend:{display:false}},
+                    scales:{y:{beginAtZero:true}}
+                  }
+                });
+              });
           </script>
         </main></body></html>
         """


### PR DESCRIPTION
## Summary
- add viewport meta tag for better responsive layout
- show commits per contributor chart alongside hours chart

## Testing
- `python -m py_compile .github/scripts/org_coding_hours.py`

------
https://chatgpt.com/codex/tasks/task_e_688afd98e1908329aae763c419cf5bd9