### PR TITLE
Refine org coding hours workflow

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -19,37 +19,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
-      with: { go-version: '1.24' }
-    - name: Install git-hours v0.1.2
-      run: |
-        git clone --depth 1 --branch v0.1.2 https://github.com/trinhminhtriet/git-hours.git git-hours-src
-        sed -i 's/go 1.24.1/go 1.24/' git-hours-src/go.mod
-        (cd git-hours-src && go install .)
-    - name: Run git-hours across repos
-      env:
-        REPOS: ${{ github.event.inputs.repos }}
-        WINDOW_START: ${{ github.event.inputs.window_start }}
-      run: |
-        python .github/scripts/org_coding_hours.py
-    - name: Push reports to metrics branch
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git config --global user.name  "git-hours bot"
-        git config --global user.email "bot@github.com"
-        git stash push --include-untracked --quiet
-        git fetch origin metrics || true
-        if git show-ref --quiet refs/remotes/origin/metrics; then
-          git switch --quiet metrics || git switch -c metrics origin/metrics
-          git pull --ff-only origin metrics || true
-        else
-          git switch --orphan metrics
-          git reset --hard
-        fi
-        git stash pop --quiet || true
-        git add reports
-        git commit -m "chore(metrics): org report $(date +%F)" || echo "No change"
-        git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics \
-        || git push --force-with-lease https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} metrics
+    - uses: LabVIEW-Community-CI-CD/org-coding-hours-action@main
+      with:
+        repos: ${{ github.event.inputs.repos }}
+        window_start: ${{ github.event.inputs.window_start }}


### PR DESCRIPTION
## Summary
- use LabVIEW-Community-CI-CD/org-coding-hours-action for org reports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bd46f99e883299cfd72ed0979e79e