### PR TITLE
Add repo-based coding hours helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ jobs:
 
 This workflow triggers manually through the GitHub UI. When run, it computes coding hours across the specified repositories, writes JSON reports to the `metrics` branch, and publishes the KPI website to the `gh-pages` branch.
 
+## Single-repository usage
+
+For a simpler setup that processes only this repository, run `scripts/repo_coding_hours.py` after checking out the repo. The script runs `git-hours` in the repository root and writes `reports/git-hours-<date>.json`. It respects the optional `WINDOW_START` environment variable.
+
+
 ## Notes
 
 * The action installs a specific version of `git‑hours` (v0.1.2) using Go 1.24 and executes a Python helper script. If you want to update the version, modify the clone command in `action.yml` accordingly.

--- a/scripts/repo_coding_hours.py
+++ b/scripts/repo_coding_hours.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Compute coding hours for the current repository using git-hours.
+
+The script determines the repository root, runs ``git-hours`` there (optionally
+passing a start date via the ``WINDOW_START`` environment variable), and writes
+``reports/git-hours-<date>.json`` with the results.
+"""
+import json
+import os
+import pathlib
+import subprocess
+import datetime
+
+SINCE = os.getenv("WINDOW_START", "")
+
+
+def repo_root() -> pathlib.Path:
+    """Return the path to the repository root via ``git rev-parse``."""
+    out = subprocess.check_output([
+        "git",
+        "rev-parse",
+        "--show-toplevel",
+    ], text=True)
+    return pathlib.Path(out.strip())
+
+
+def run_git_hours(path: pathlib.Path) -> dict:
+    """Run ``git-hours`` in the given directory and return parsed JSON output."""
+    cmd = ["git-hours"]
+    if SINCE:
+        cmd.extend(["-since", SINCE])
+    out = subprocess.check_output(cmd, cwd=path, text=True)
+    return json.loads(out)
+
+
+def main() -> None:
+    root = repo_root()
+    data = run_git_hours(root)
+    date = datetime.date.today().isoformat()
+    reports = root / "reports"
+    reports.mkdir(exist_ok=True)
+    (reports / f"git-hours-{date}.json").write_text(json.dumps(data, indent=2))
+    print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- script to run `git-hours` on the current repo
- document single-repo usage in README

## Testing
- `python -m py_compile scripts/repo_coding_hours.py`
- `python -m compileall -q scripts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c36046d8083298cf4e07554a69bba