### PR TITLE
Fix org-coding-hours artifact upload

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -23,6 +23,11 @@ jobs:
       uses: LabVIEW-Community-CI-CD/org-coding-hours-action@v3
       with:
         repos: ni/labview-icon-editor ni/actor-framework ni/open-source
+    - uses: actions/upload-artifact@v4
+      with:
+        name: git-hours-aggregated-json
+        path: reports/git-hours-*.json
+        retention-days: 30
 
   build-site:
     needs: report


### PR DESCRIPTION
## Summary
- upload JSON reports after running the org-coding-hours action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c3caba978832997919c525fc1a05d