### PR TITLE
Fix build-site artifact download

### DIFF
--- a/.github/workflows/org-coding-hours.yml
+++ b/.github/workflows/org-coding-hours.yml
@@ -20,9 +20,13 @@ jobs:
     - uses: actions/setup-go@v4
       with: { go-version: '1.24' }
     - name: Run Org Coding Hours Action
+      id: org_hours
       uses: LabVIEW-Community-CI-CD/org-coding-hours-action@v3
       with:
         repos: ni/labview-icon-editor ni/actor-framework ni/open-source
+        window_start: ${{ github.event.inputs.window_start }}
+    - name: Restore reports from metrics branch
+      run: git archive metrics reports | tar -x
     - uses: actions/upload-artifact@v4
       with:
         name: git-hours-aggregated-json

--- a/docs/coding-hours.md
+++ b/docs/coding-hours.md
@@ -4,9 +4,10 @@ This page explains how the repository generates contributor hours and where the 
 
 ## How the workflow works
 
-The **Coding-hours report** workflow runs weekly and can also be triggered manually. It leverages the [Org Coding Hours Action](https://github.com/LabVIEW-Community-CI-CD/org-coding-hours-action) to compute statistics and publish the results. It performs the following steps:
+The **Coding-hours report** workflow runs weekly and can also be triggered manually. It leverages the [Org Coding Hours Action](https://github.com/LabVIEW-Community-CI-CD/org-coding-hours-action) to gather statistics across multiple repositories and publish the results. It performs the following steps:
 
-1. **Collect statistics** – The job checks out all three repositories and runs `git-hours` to calculate commit hours per contributor. The aggregated report is saved as `git-hours.json` and archived as a workflow artifact.
+1. **Collect statistics** – The job checks out all three repositories and runs `git-hours` to calculate commit hours per contributor. The aggregated report is saved as `git-hours-aggregated-<date>.json` and archived as a workflow artifact.
+   The Org Coding Hours Action commits the reports to a dedicated `metrics` branch, so the workflow pulls them back from that branch before archiving.
 2. **Build the KPIs site** – Using this aggregated data, a simple HTML dashboard is generated under a `site/` directory. This directory is then uploaded as a Pages artifact. The page includes a section for each repository in addition to organization-wide totals.
 3. **Deploy** – The site artifact is deployed to GitHub Pages so everyone can view the latest dashboard covering all repositories.
 


### PR DESCRIPTION
## Summary
- restore reports from metrics branch after running the Org Coding Hours Action
- document how reports are recovered from the metrics branch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c40a8cafc8329a5e5e1e2cdf3c0ee