### PR TITLE
Add deterministic per-VIPB lock broker and coverage

### DIFF
--- a/.github/actions/build-vip/README.md
+++ b/.github/actions/build-vip/README.md
@@ -17,6 +17,13 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
 | `commit` | **Yes** | `abcdef` | Commit identifier. |
 | `release_notes_file` | **Yes** | `Tooling/deployment/release_notes.md` | Release notes file. |
 | `display_information_json` | **Yes** | `'{}'` | JSON for VIPB display information. |
+| `vipb_build_lock_timeout_seconds` | No (defaults to `180`) | `180` | Timeout waiting for per-VIPB lock acquisition. |
+| `vipb_build_lock_stale_seconds` | No (defaults to `300`) | `300` | Lock age threshold used to recover stale lock folders. |
+
+## Collision Guardrail
+- Builds acquire a per-`vipb` lock keyed by normalized VIPB path.
+- The lock root resolves in this order: `LVIE_LOCK_ROOT`, `RUNNER_TEMP`, `TEMP`, then `<repo>\builds\locks`.
+- If an existing lock is older than `vipb_build_lock_stale_seconds`, it is treated as stale and replaced.
 
 ## Quick-start
 ```yaml
@@ -32,6 +39,8 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
     commit: ${{ github.sha }}
     release_notes_file: Tooling/deployment/release_notes.md
     display_information_json: '{}'
+    vipb_build_lock_timeout_seconds: 180
+    vipb_build_lock_stale_seconds: 300
 ```
 
 ## License

--- a/.github/actions/build-vip/README.md
+++ b/.github/actions/build-vip/README.md
@@ -8,8 +8,8 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
 | `supported_bitness` | **Yes** | `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `vipb_path` | **Yes** | `Tooling/deployment/NI Icon editor.vipb` | Path to the VIPB file. |
-| `labview_version` | No | `2021` | LabVIEW 2021 (21.0). Defaults to `.lvversion` and fails if it conflicts. |
-| `labview_minor_revision` | No | `0` | LabVIEW minor revision. Defaults to `.lvversion` and fails if it conflicts. |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `labview_minor_revision` | No (defaults to `0`) | `0` | LabVIEW minor revision. |
 | `major` | **Yes** | `1` | Major version component. |
 | `minor` | **Yes** | `0` | Minor version component. |
 | `patch` | **Yes** | `0` | Patch version component. |
@@ -25,6 +25,13 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
 - The lock root resolves in this order: `LVIE_LOCK_ROOT`, `RUNNER_TEMP`, `TEMP`, then `<repo>\builds\locks`.
 - If an existing lock is older than `vipb_build_lock_stale_seconds`, it is treated as stale and replaced.
 
+## VIPM Port Guardrail
+- Before invoking `vipm build`, the action validates VIPM target port mapping against `LabVIEW.ini` (`server.tcp.port`) for the selected LabVIEW version/bitness.
+- The build fails fast on mismatch to prevent package operations from targeting the wrong LabVIEW instance.
+- Manual check/fix helper:
+  - `pwsh -NoProfile -File .\Tooling\Assert-VipmPortAlignment.ps1 -LabVIEWVersion 2020 -LabVIEWBitness 32`
+  - `pwsh -NoProfile -File .\Tooling\Assert-VipmPortAlignment.ps1 -LabVIEWVersion 2020 -LabVIEWBitness 32 -Fix`
+
 ## Quick-start
 ```yaml
 - uses: ./.github/actions/build-vip
@@ -32,6 +39,7 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
     vipb_path: Tooling/deployment/NI Icon editor.vipb
+    labview_version: 2021
     major: 1
     minor: 0
     patch: 0

--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -161,7 +161,9 @@ runs:
           -Build ${{ inputs.build }} `
           -Commit "${{ inputs.commit }}" `
           -ReleaseNotesFile "${{ inputs.release_notes_file }}" `
-          -DisplayInformationJSON $displayInformationJson
+          -DisplayInformationJSON $displayInformationJson `
+          -VipbBuildLockTimeoutSeconds ${{ inputs.vipb_build_lock_timeout_seconds }} `
+          -VipbBuildLockStaleSeconds ${{ inputs.vipb_build_lock_stale_seconds }}
 
     - name: Dump VIPM build logs on failure
       if: failure()
@@ -317,6 +319,14 @@ inputs:
     description: 'If true, fail when multiple .vip files exist after the build step'
     required: false
     default: 'true'
+  vipb_build_lock_timeout_seconds:
+    description: 'Timeout waiting for VIPB build lock acquisition.'
+    required: false
+    default: '180'
+  vipb_build_lock_stale_seconds:
+    description: 'Age at which an existing VIPB build lock is treated as stale and recoverable.'
+    required: false
+    default: '300'
 
 
 

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -75,7 +75,13 @@ param (
     [string]$DisplayInformationJsonPath,
 
     [ValidateRange(60, 3600)]
-    [int]$VipmTimeoutSeconds = 300
+    [int]$VipmTimeoutSeconds = 300,
+
+    [ValidateRange(30, 7200)]
+    [int]$VipbBuildLockTimeoutSeconds = 180,
+
+    [ValidateRange(60, 86400)]
+    [int]$VipbBuildLockStaleSeconds = 300
 )
 
 # 1) Resolve paths
@@ -113,6 +119,18 @@ if (Test-Path -Path $preflightScript) {
     }
     $ResolvedRepoRoot = $preflight.RepoRoot
 }
+
+$vipbLockSupportScript = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\VipbBuildLock.ps1'
+if (-not (Test-Path -Path $vipbLockSupportScript -PathType Leaf)) {
+    $errorObject = [PSCustomObject]@{
+        error = "VIPB lock support script not found."
+        path  = $vipbLockSupportScript
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+. $vipbLockSupportScript
+$vipbBuildLockPath = $null
 
 # 1b) Resolve LabVIEW version against .lvversion (fail-fast on mismatch)
 $sourceLabVIEWVersionRaw = $LabVIEWVersion
@@ -478,6 +496,14 @@ function Set-VipmTargetSettingsFromContract {
     }
 }
 
+$lockRoot = Get-VipbBuildLockRoot -RepoRoot $ResolvedRepoRoot
+$vipbBuildLockPath = Acquire-VipbBuildLock `
+    -LockRoot $lockRoot `
+    -VipbPath $ResolvedVIPBPath `
+    -TimeoutSeconds $VipbBuildLockTimeoutSeconds `
+    -StaleSeconds $VipbBuildLockStaleSeconds
+
+try {
 # 1b) Ensure VI Package output directory exists to avoid VIPM prompts
 $artifactRoot = $env:LVIE_ARTIFACT_ROOT
 $vipOutputDir = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
@@ -719,5 +745,11 @@ if (-not [string]::IsNullOrWhiteSpace($artifactRoot)) {
         }
     } catch {
         Write-Warning ("Failed to copy .vip to artifact root: {0}" -f $_.Exception.Message)
+    }
+}
+}
+finally {
+    if (-not [string]::IsNullOrWhiteSpace($vipbBuildLockPath)) {
+        Release-VipbBuildLock -LockPath $vipbBuildLockPath
     }
 }

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -4,7 +4,7 @@
 
 .DESCRIPTION
     Resolves paths, merges version details into DisplayInformation JSON, and
-    invokes VIPM CLI to build the final VI package.
+    calls PowerShell + VIPM CLI to modify the VIPB file and create the final VI package.
 
 .PARAMETER SupportedBitness
     LabVIEW bitness for the build ("32" or "64").
@@ -17,11 +17,7 @@
 
 .PARAMETER LabVIEWVersion
     LabVIEW major version year (e.g., 2021).
-
-.PARAMETER ExecutionLabVIEWYear
-    Optional execution-time LabVIEW year override for runtime operations.
-    When omitted, runtime operations use the LabVIEW year resolved from
-    LabVIEWVersion / .lvversion.
+    Alias: MinimumSupportedLVVersion.
 
 .PARAMETER LabVIEWMinorRevision
     Minor revision number of LabVIEW (e.g., 0 for 21.0).
@@ -48,7 +44,7 @@
     JSON string representing the VIPB display information to update.
 
 .EXAMPLE
-    .\build_vip.ps1 -SupportedBitness "64" -RepoRoot "C:\repo" -VIPBPath "Tooling\deployment\NI Icon editor.vipb" -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit "abcd123" -ReleaseNotesFile "Tooling\deployment\release_notes.md" -DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
+    .\build_vip.ps1 -SupportedBitness "64" -RepoRoot "C:\repo" -VIPBPath "Tooling\deployment\NI Icon editor.vipb" -LabVIEWVersion 2021 -LabVIEWMinorRevision 0 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit "abcd123" -ReleaseNotesFile "Tooling\deployment\release_notes.md" -DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
 #>
 
 param (
@@ -58,8 +54,9 @@ param (
     [string]$WorktreeRoot,
     [switch]$SkipWorktreeRootCheck,
 
-    [string]$LabVIEWVersion,
-    [string]$ExecutionLabVIEWYear,
+    [Alias('MinimumSupportedLVVersion')]
+    [ValidateRange(2000, 2100)]
+    [int]$LabVIEWVersion,
 
     [ValidateRange(0, 99)]
     [int]$LabVIEWMinorRevision = 0,
@@ -83,6 +80,8 @@ param (
     [ValidateRange(60, 86400)]
     [int]$VipbBuildLockStaleSeconds = 300
 )
+
+$vipbBuildLockPath = $null
 
 # 1) Resolve paths
 try {
@@ -120,8 +119,32 @@ if (Test-Path -Path $preflightScript) {
     $ResolvedRepoRoot = $preflight.RepoRoot
 }
 
+$vipmPortGuardScript = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\VipmPortAlignment.ps1'
+if (-not (Test-Path -Path $vipmPortGuardScript)) {
+    $errorObject = [PSCustomObject]@{
+        error = "VIPM port guard script not found."
+        path  = $vipmPortGuardScript
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+. $vipmPortGuardScript
+
+$portCheck = Test-VipmTargetPortAlignment -LabVIEWVersion $LabVIEWVersion -Bitness $SupportedBitness
+if (-not $portCheck.passed) {
+    $errorObject = [PSCustomObject]@{
+        error = "VIPM target port mismatch detected for LabVIEW $LabVIEWVersion ($SupportedBitness-bit)."
+        mismatchCount = $portCheck.mismatch_count
+        mismatches = $portCheck.mismatches
+        settingsPath = $portCheck.settings_path
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+Write-Host ("VIPM port guard passed for LabVIEW {0} ({1}-bit)." -f $LabVIEWVersion, $SupportedBitness)
+
 $vipbLockSupportScript = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\VipbBuildLock.ps1'
-if (-not (Test-Path -Path $vipbLockSupportScript -PathType Leaf)) {
+if (-not (Test-Path -Path $vipbLockSupportScript)) {
     $errorObject = [PSCustomObject]@{
         error = "VIPB lock support script not found."
         path  = $vipbLockSupportScript
@@ -130,609 +153,263 @@ if (-not (Test-Path -Path $vipbLockSupportScript -PathType Leaf)) {
     exit 1
 }
 . $vipbLockSupportScript
-$vipbBuildLockPath = $null
 
-# 1b) Resolve LabVIEW version against .lvversion (fail-fast on mismatch)
-$sourceLabVIEWVersionRaw = $LabVIEWVersion
-$sourceLabVIEWYear = $null
-$versionHelper = Join-Path $ResolvedRepoRoot 'Tooling\support\LabVIEWVersion.ps1'
-if (Test-Path -Path $versionHelper) {
-    . $versionHelper
-    $repoInfo = Get-LabVIEWVersionInfo -RepoRoot $ResolvedRepoRoot
-    $inputProvided = $PSBoundParameters.ContainsKey('LabVIEWVersion') -and -not [string]::IsNullOrWhiteSpace([string]$LabVIEWVersion)
-    if ($inputProvided) {
-        $inputInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $ResolvedRepoRoot
-        $sourceLabVIEWVersionRaw = [string]$inputInfo.Raw
-        $sourceLabVIEWYear = [string]$inputInfo.Year
+try {
+    $lockRoot = Get-VipbBuildLockRoot -RepoRoot $ResolvedRepoRoot
+    $vipbBuildLockPath = New-VipbBuildLockLease `
+        -LockRoot $lockRoot `
+        -VipbPath $ResolvedVIPBPath `
+        -TimeoutSeconds $VipbBuildLockTimeoutSeconds `
+        -StaleSeconds $VipbBuildLockStaleSeconds
+
+    # 1b) Ensure VI Package output directory exists to avoid VIPM prompts
+    $artifactRoot = $env:LVIE_ARTIFACT_ROOT
+    $vipOutputDir = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
+        Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/VI Package"
     } else {
-        $sourceLabVIEWVersionRaw = [string]$repoInfo.Raw
-        $sourceLabVIEWYear = [string]$repoInfo.Year
-        Write-Warning "LabVIEWVersion not provided; defaulting to .lvversion ($($repoInfo.Raw))."
+        Join-Path -Path $artifactRoot -ChildPath "builds/VI Package"
     }
+    New-Item -ItemType Directory -Path $vipOutputDir -Force | Out-Null
 
-    if ($PSBoundParameters.ContainsKey('LabVIEWMinorRevision')) {
-        if ([int]$LabVIEWMinorRevision -ne [int]$repoInfo.MinorRevision) {
-            throw "LabVIEWMinorRevision '$LabVIEWMinorRevision' does not match .lvversion minor '$($repoInfo.MinorRevision)'."
-        }
-    } else {
-        $LabVIEWMinorRevision = [int]$repoInfo.MinorRevision
-    }
-}
-
-if ([string]::IsNullOrWhiteSpace($sourceLabVIEWYear) -and -not [string]::IsNullOrWhiteSpace($sourceLabVIEWVersionRaw)) {
-    if ($sourceLabVIEWVersionRaw -match '^(?<major>\d{2,4})(?:\.\d+)?$') {
-        $major = [int]$Matches['major']
-        $sourceLabVIEWYear = if ($major -ge 2000) { $major.ToString() } else { (2000 + $major).ToString() }
-    }
-}
-if ([string]::IsNullOrWhiteSpace($sourceLabVIEWYear)) {
-    throw "Failed to resolve LabVIEW source year from LabVIEWVersion/.lvversion."
-}
-
-$resolvedExecutionLabVIEWYear = if ([string]::IsNullOrWhiteSpace($ExecutionLabVIEWYear)) {
-    $sourceLabVIEWYear
-} else {
-    $ExecutionLabVIEWYear.Trim()
-}
-if ($resolvedExecutionLabVIEWYear -notmatch '^\d{4}$') {
-    throw ("ExecutionLabVIEWYear '{0}' is invalid. Expected a four-digit year such as 2026." -f $resolvedExecutionLabVIEWYear)
-}
-
-$yearCompatMappingApplied = [string]::Equals($sourceLabVIEWYear, '2020', [System.StringComparison]::OrdinalIgnoreCase) -and
-    [string]::Equals($resolvedExecutionLabVIEWYear, '2026', [System.StringComparison]::OrdinalIgnoreCase)
-Write-Output ("LabVIEW source contract: raw={0}; year={1}; minor={2}" -f $sourceLabVIEWVersionRaw, $sourceLabVIEWYear, $LabVIEWMinorRevision)
-Write-Output ("LabVIEW execution year: {0}" -f $resolvedExecutionLabVIEWYear)
-Write-Output ("LabVIEW execution-year compatibility mapping applied: {0}" -f $yearCompatMappingApplied)
-if ($yearCompatMappingApplied) {
-    Write-Output "LabVIEW execution-year compatibility mapping: source year 2020 -> execution year 2026"
-}
-
-function Get-VipmTargetVersionLabel {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$LabVIEWNumericVersion,
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('32', '64')]
-        [string]$Bitness
-    )
-
-    if ($Bitness -eq '64') {
-        return "$LabVIEWNumericVersion (64-bit)"
-    }
-
-    return $LabVIEWNumericVersion
-}
-
-function Get-VipmSettingsPath {
-    if ([string]::IsNullOrWhiteSpace($env:ProgramData)) {
-        throw 'ProgramData is not defined; cannot resolve VIPM settings file.'
-    }
-
-    return Join-Path -Path $env:ProgramData -ChildPath 'JKI\VIPM\Settings.ini'
-}
-
-function Get-VipmTargetsSectionInfo {
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [string[]]$Lines
-    )
-
-    $inTargets = $false
-    $versions = @{}
-    $portsLineIndex = -1
-    $portsSize = 0
-    $ports = @()
-    $connectionTimeoutLineIndex = -1
-    $connectionTimeoutValue = $null
-
-    for ($index = 0; $index -lt $Lines.Count; $index++) {
-        $line = [string]$Lines[$index]
-        $sectionMatch = [regex]::Match($line, '^\s*\[(?<name>[^\]]+)\]\s*$')
-        if ($sectionMatch.Success) {
-            $sectionName = $sectionMatch.Groups['name'].Value.Trim()
-            if ($sectionName -eq 'Targets') {
-                $inTargets = $true
-                continue
-            }
-
-            if ($inTargets) {
-                break
-            }
-        }
-
-        if (-not $inTargets) {
-            continue
-        }
-
-        $versionMatch = [regex]::Match($line, '^\s*Versions\s+(?<idx>\d+)\s*=\s*"(?<value>.*)"\s*$')
-        if ($versionMatch.Success) {
-            $versions[[int]$versionMatch.Groups['idx'].Value] = $versionMatch.Groups['value'].Value
-            continue
-        }
-
-        $portsMatch = [regex]::Match($line, '^\s*Ports\s*=\s*"(?<value><size\(s\)=\d+>.*)"\s*$')
-        if ($portsMatch.Success) {
-            $portsLineIndex = $index
-            $portsRaw = $portsMatch.Groups['value'].Value
-            $sizeMatch = [regex]::Match($portsRaw, '<size\(s\)=(?<n>\d+)>')
-            if ($sizeMatch.Success) {
-                $portsSize = [int]$sizeMatch.Groups['n'].Value
-                $rest = $portsRaw.Substring($sizeMatch.Index + $sizeMatch.Length).Trim()
-                if (-not [string]::IsNullOrWhiteSpace($rest)) {
-                    $ports = @($rest -split '\s+')
+    # 1c) Resolve VIPB output folder + package name to pre-clean existing VIP
+    $vipbOutputDir = $null
+    $packageFileName = $null
+    try {
+        $vipbXml = [xml](Get-Content -Raw -Path $ResolvedVIPBPath)
+        $general = $vipbXml.VI_Package_Builder_Settings.Library_General_Settings
+        if ($general) {
+            $packageFileName = $general.Package_File_Name
+            $outputFolder = $general.Library_Output_Folder
+            if (-not [string]::IsNullOrWhiteSpace($outputFolder)) {
+                $vipbRoot = Split-Path -Path $ResolvedVIPBPath -Parent
+                $vipbOutputDir = if ([System.IO.Path]::IsPathRooted($outputFolder)) {
+                    $outputFolder
+                } else {
+                    Join-Path -Path $vipbRoot -ChildPath $outputFolder
                 }
-            }
-            continue
-        }
-
-        $timeoutMatch = [regex]::Match($line, '^\s*Connection Timeout\s*=\s*"(?<value>\d+)"\s*$')
-        if ($timeoutMatch.Success) {
-            $connectionTimeoutLineIndex = $index
-            $connectionTimeoutValue = [int]$timeoutMatch.Groups['value'].Value
-        }
-    }
-
-    return [pscustomobject]@{
-        Versions                   = $versions
-        PortsLineIndex             = $portsLineIndex
-        PortsSize                  = $portsSize
-        Ports                      = @($ports)
-        ConnectionTimeoutLineIndex = $connectionTimeoutLineIndex
-        ConnectionTimeoutValue     = $connectionTimeoutValue
-    }
-}
-
-function Find-LineIndex {
-    param(
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyCollection()]
-        [string[]]$Lines,
-        [Parameter(Mandatory = $true)]
-        [string]$Pattern,
-        [Parameter()]
-        [int]$StartIndex = 0
-    )
-
-    if ($StartIndex -lt 0) {
-        $StartIndex = 0
-    }
-
-    for ($index = $StartIndex; $index -lt $Lines.Count; $index++) {
-        if ([regex]::IsMatch([string]$Lines[$index], $Pattern)) {
-            return $index
-        }
-    }
-
-    return -1
-}
-
-function Set-VipmTargetSettingsFromContract {
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoRoot,
-        [Parameter(Mandatory = $true)]
-        [string]$VersionYear,
-        [Parameter(Mandatory = $true)]
-        [ValidateRange(0, 99)]
-        [int]$MinorRevision,
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('32', '64')]
-        [string]$Bitness,
-        [Parameter(Mandatory = $true)]
-        [ValidateRange(60, 3600)]
-        [int]$ConnectionTimeoutSeconds
-    )
-
-    $labviewExecutablePathHelper = Join-Path $RepoRoot 'Tooling\support\LabVIEWExecutablePath.ps1'
-    if (-not (Test-Path -Path $labviewExecutablePathHelper -PathType Leaf)) {
-        throw "LabVIEW executable resolver helper not found at $labviewExecutablePathHelper"
-    }
-
-    $portContractHelper = Join-Path $RepoRoot 'Tooling\support\LabVIEWCliPortContract.ps1'
-    if (-not (Test-Path -Path $portContractHelper -PathType Leaf)) {
-        throw "LabVIEW CLI port contract helper not found at $portContractHelper"
-    }
-
-    . $labviewExecutablePathHelper
-    . $portContractHelper
-
-    $numericVersion = "{0}.{1}" -f ([int]$VersionYear - 2000), $MinorRevision
-    $targetVersionLabel = Get-VipmTargetVersionLabel -LabVIEWNumericVersion $numericVersion -Bitness $Bitness
-    $requestedTargetVersionLabel = $targetVersionLabel
-    $settingsPath = Get-VipmSettingsPath
-    if (-not (Test-Path -Path $settingsPath -PathType Leaf)) {
-        throw "VIPM settings file not found at $settingsPath"
-    }
-
-    $settingsRaw = Get-Content -Path $settingsPath -Raw -ErrorAction Stop
-    if ([string]::IsNullOrWhiteSpace($settingsRaw)) {
-        throw ("VIPM settings file '{0}' is empty." -f $settingsPath)
-    }
-    $normalized = $settingsRaw -replace "`r`n", "`n" -replace "`r", "`n"
-    $lines = @($normalized -split "`n")
-    $sectionInfo = Get-VipmTargetsSectionInfo -Lines $lines
-    if ($sectionInfo.PortsLineIndex -lt 0) {
-        throw "VIPM settings file '$settingsPath' does not define Targets.Ports."
-    }
-    if ($sectionInfo.ConnectionTimeoutLineIndex -lt 0) {
-        throw "VIPM settings file '$settingsPath' does not define Targets.Connection Timeout."
-    }
-    if ($sectionInfo.Versions.Count -eq 0) {
-        throw "VIPM settings file '$settingsPath' does not define Targets.Versions entries."
-    }
-
-    $targetIndex = $null
-    foreach ($entry in $sectionInfo.Versions.GetEnumerator() | Sort-Object Key) {
-        if ([string]::Equals([string]$entry.Value, $targetVersionLabel, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $targetIndex = [int]$entry.Key
-            break
-        }
-    }
-    if ($null -eq $targetIndex) {
-        $executionNumericMajor = [int]$VersionYear - 2000
-        $majorCompatibleTargets = New-Object 'System.Collections.Generic.List[object]'
-        foreach ($entry in $sectionInfo.Versions.GetEnumerator() | Sort-Object Key) {
-            $candidateLabel = [string]$entry.Value
-            if ([string]::IsNullOrWhiteSpace($candidateLabel)) {
-                continue
-            }
-
-            $candidateBitness = if ($candidateLabel -match '\(64-bit\)\s*$') { '64' } else { '32' }
-            if ($candidateBitness -ne $Bitness) {
-                continue
-            }
-
-            $candidateNumericLabel = if ($candidateBitness -eq '64') {
-                ($candidateLabel -replace '\s+\(64-bit\)\s*$', '').Trim()
-            } else {
-                $candidateLabel.Trim()
-            }
-
-            if ($candidateNumericLabel -match '^(?<major>\d+)\.(?<minor>\d+)$' -and [int]$Matches['major'] -eq $executionNumericMajor) {
-                $majorCompatibleTargets.Add([pscustomobject]@{
-                    Index = [int]$entry.Key
-                    Label = $candidateLabel
-                    Minor = [int]$Matches['minor']
-                }) | Out-Null
+                $vipbOutputDir = [System.IO.Path]::GetFullPath($vipbOutputDir)
             }
         }
-
-        if ($majorCompatibleTargets.Count -gt 0) {
-            $selectedTarget = $majorCompatibleTargets |
-                Sort-Object -Property @{ Expression = 'Minor'; Descending = $true }, @{ Expression = 'Index'; Descending = $false } |
-                Select-Object -First 1
-            $targetIndex = [int]$selectedTarget.Index
-            $targetVersionLabel = [string]$selectedTarget.Label
-            Write-Warning ("VIPM target fallback applied: requested '{0}' not found; using major-compatible target '{1}' from '{2}'." -f $requestedTargetVersionLabel, $targetVersionLabel, $settingsPath)
-        } else {
-            throw ("VIPM settings file '{0}' does not define target version '{1}' under [Targets]." -f $settingsPath, $targetVersionLabel)
-        }
+    } catch {
+        Write-Warning ("Failed to parse VIPB output folder: {0}" -f $_.Exception.Message)
     }
 
-    $labviewExecutablePath = Resolve-LabVIEWExecutablePath -VersionYear $VersionYear -Bitness $Bitness
-    $portResolution = Resolve-LabVIEWCliPortFromContract `
-        -RepoRoot $RepoRoot `
-        -LabVIEWVersion $numericVersion `
-        -Bitness $Bitness `
-        -LabVIEWExecutablePath $labviewExecutablePath
-    $expectedPort = [int]$portResolution.PortNumber
-
-    $ports = New-Object 'System.Collections.Generic.List[string]'
-    foreach ($entry in @($sectionInfo.Ports)) {
-        $ports.Add([string]$entry) | Out-Null
-    }
-    while ($ports.Count -lt [int]$sectionInfo.PortsSize) {
-        $ports.Add('0') | Out-Null
-    }
-    while ($ports.Count -le $targetIndex) {
-        $ports.Add('0') | Out-Null
+    # 2) Create release notes if needed and resolve the paths
+    if (-not (Test-Path $ReleaseNotesFile)) {
+        Write-Host "Release notes file '$ReleaseNotesFile' does not exist. Creating it..."
+        New-Item -ItemType File -Path $ReleaseNotesFile -Force | Out-Null
     }
 
-    $linesList = New-Object 'System.Collections.Generic.List[string]'
-    $linesList.AddRange([string[]]$lines)
-
-    $updated = $false
-    $currentPort = [string]$ports[$targetIndex]
-    if ($currentPort -ne $expectedPort.ToString()) {
-        Write-Output ("Updating VIPM target port for '{0}' (index {1}) from {2} to {3}." -f $targetVersionLabel, $targetIndex, $currentPort, $expectedPort)
-        $ports[$targetIndex] = $expectedPort.ToString()
-        $updated = $true
-    } else {
-        Write-Output ("VIPM target port already matches contract for '{0}': {1}" -f $targetVersionLabel, $expectedPort)
+    try {
+        $ResolvedReleaseNotesFile = Resolve-Path -Path $ReleaseNotesFile -ErrorAction Stop
     }
-
-    $currentTimeout = [int]$sectionInfo.ConnectionTimeoutValue
-    if ($currentTimeout -ne $ConnectionTimeoutSeconds) {
-        Write-Output ("Updating VIPM Connection Timeout from {0} to {1} seconds." -f $currentTimeout, $ConnectionTimeoutSeconds)
-        $linesList[$sectionInfo.ConnectionTimeoutLineIndex] = ('Connection Timeout="{0}"' -f $ConnectionTimeoutSeconds)
-        $updated = $true
-    } else {
-        Write-Output ("VIPM Connection Timeout already set to {0} seconds." -f $currentTimeout)
-    }
-
-    $targetVersionLine = ('Active Target.Version="{0}"' -f $targetVersionLabel)
-    $activeTargetVersionIndex = Find-LineIndex -Lines $linesList.ToArray() -Pattern '^\s*Active Target\.Version\s*='
-    if ($activeTargetVersionIndex -ge 0) {
-        if (-not [string]::Equals([string]$linesList[$activeTargetVersionIndex], $targetVersionLine, [System.StringComparison]::Ordinal)) {
-            Write-Output ("Updating VIPM active target version from '{0}' to '{1}'." -f [string]$linesList[$activeTargetVersionIndex], $targetVersionLabel)
-            $linesList[$activeTargetVersionIndex] = $targetVersionLine
-            $updated = $true
-        }
-    } else {
-        $insertAt = [Math]::Min($sectionInfo.ConnectionTimeoutLineIndex + 1, $linesList.Count)
-        Write-Output ("Adding VIPM active target version '{0}'." -f $targetVersionLabel)
-        $linesList.Insert($insertAt, $targetVersionLine)
-        $updated = $true
-    }
-
-    $targetNameLine = 'Active Target.Name="LabVIEW"'
-    $activeTargetNameIndex = Find-LineIndex -Lines $linesList.ToArray() -Pattern '^\s*Active Target\.Name\s*='
-    if ($activeTargetNameIndex -ge 0) {
-        if (-not [string]::Equals([string]$linesList[$activeTargetNameIndex], $targetNameLine, [System.StringComparison]::Ordinal)) {
-            Write-Output ("Updating VIPM active target name from '{0}' to 'LabVIEW'." -f [string]$linesList[$activeTargetNameIndex])
-            $linesList[$activeTargetNameIndex] = $targetNameLine
-            $updated = $true
-        }
-    } else {
-        $connectionTimeoutIndex = Find-LineIndex -Lines $linesList.ToArray() -Pattern '^\s*Connection Timeout\s*='
-        $insertAt = if ($connectionTimeoutIndex -ge 0) { [Math]::Min($connectionTimeoutIndex + 1, $linesList.Count) } else { $linesList.Count }
-        Write-Output "Adding VIPM active target name 'LabVIEW'."
-        $linesList.Insert($insertAt, $targetNameLine)
-        $updated = $true
-    }
-
-    if ($updated -and $PSCmdlet.ShouldProcess($settingsPath, 'Synchronize VIPM target port and connection timeout with LabVIEW contract')) {
-        $portsSize = $ports.Count
-        $portsValue = if ($portsSize -gt 0) {
-            "<size(s)=$portsSize> " + (($ports.ToArray()) -join ' ')
-        } else {
-            "<size(s)=0>"
-        }
-        $linesList[$sectionInfo.PortsLineIndex] = ('Ports="{0}"' -f $portsValue)
-        Set-Content -Path $settingsPath -Value $linesList.ToArray() -Encoding utf8
-        Write-Output ("VIPM settings synchronized to LabVIEW CLI contract: {0}" -f $settingsPath)
-    }
-}
-
-$lockRoot = Get-VipbBuildLockRoot -RepoRoot $ResolvedRepoRoot
-$vipbBuildLockPath = Acquire-VipbBuildLock `
-    -LockRoot $lockRoot `
-    -VipbPath $ResolvedVIPBPath `
-    -TimeoutSeconds $VipbBuildLockTimeoutSeconds `
-    -StaleSeconds $VipbBuildLockStaleSeconds
-
-try {
-# 1b) Ensure VI Package output directory exists to avoid VIPM prompts
-$artifactRoot = $env:LVIE_ARTIFACT_ROOT
-$vipOutputDir = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
-    Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/VI Package"
-} else {
-    Join-Path -Path $artifactRoot -ChildPath "builds/VI Package"
-}
-New-Item -ItemType Directory -Path $vipOutputDir -Force | Out-Null
-
-# 1c) Resolve VIPB output folder + package name to pre-clean existing VIP
-$vipbOutputDir = $null
-$packageFileName = $null
-try {
-    $vipbXml = [xml](Get-Content -Raw -Path $ResolvedVIPBPath)
-    $general = $vipbXml.VI_Package_Builder_Settings.Library_General_Settings
-    if ($general) {
-        $packageFileName = $general.Package_File_Name
-        $outputFolder = $general.Library_Output_Folder
-        if (-not [string]::IsNullOrWhiteSpace($outputFolder)) {
-            $vipbRoot = Split-Path -Path $ResolvedVIPBPath -Parent
-            $vipbOutputDir = if ([System.IO.Path]::IsPathRooted($outputFolder)) {
-                $outputFolder
-            } else {
-                Join-Path -Path $vipbRoot -ChildPath $outputFolder
-            }
-            $vipbOutputDir = [System.IO.Path]::GetFullPath($vipbOutputDir)
-        }
-    }
-} catch {
-    Write-Warning ("Failed to parse VIPB output folder: {0}" -f $_.Exception.Message)
-}
-
-# 2) Create release notes if needed and resolve the paths
-if (-not (Test-Path $ReleaseNotesFile)) {
-    Write-Host "Release notes file '$ReleaseNotesFile' does not exist. Creating it..."
-    New-Item -ItemType File -Path $ReleaseNotesFile -Force | Out-Null
-}
-
-try {
-    $ResolvedReleaseNotesFile = Resolve-Path -Path $ReleaseNotesFile -ErrorAction Stop
-}
-catch {
-    $errorObject = [PSCustomObject]@{
-        error      = "Error resolving ReleaseNotesFile. Ensure the path exists and is accessible."
-        exception  = $_.Exception.Message
-        stackTrace = $_.Exception.StackTrace
-    }
-    $errorObject | ConvertTo-Json -Depth 10
-    exit 1
-}
-
-# 3a) Ensure build log directory exists for troubleshooting
-$LogDirectory = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
-    Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/logs"
-} else {
-    Join-Path -Path $artifactRoot -ChildPath "builds/logs"
-}
-New-Item -ItemType Directory -Path $LogDirectory -Force | Out-Null
-
-# 3) Calculate the LabVIEW version string
-$lvNumericMajor    = [int]$resolvedExecutionLabVIEWYear - 2000
-$lvNumericVersion  = "$($lvNumericMajor).$LabVIEWMinorRevision"
-if ($SupportedBitness -eq "64") {
-    $VIP_LVVersion_A = "$lvNumericVersion (64-bit)"
-}
-else {
-    $VIP_LVVersion_A = $lvNumericVersion
-}
-Write-Output "Building VI Package for LabVIEW $VIP_LVVersion_A..."
-
-# 4) Resolve and parse DisplayInformation JSON
-$resolvedDisplayJson = $DisplayInformationJSON
-if ([string]::IsNullOrWhiteSpace($resolvedDisplayJson) -and -not [string]::IsNullOrWhiteSpace($DisplayInformationJsonPath)) {
-    if (-not (Test-Path -Path $DisplayInformationJsonPath)) {
+    catch {
         $errorObject = [PSCustomObject]@{
-            error      = "DisplayInformationJsonPath '$DisplayInformationJsonPath' does not exist."
+            error      = "Error resolving ReleaseNotesFile. Ensure the path exists and is accessible."
+            exception  = $_.Exception.Message
+            stackTrace = $_.Exception.StackTrace
         }
         $errorObject | ConvertTo-Json -Depth 10
         exit 1
     }
-    $resolvedDisplayJson = Get-Content -Raw -Path $DisplayInformationJsonPath
-}
-if ([string]::IsNullOrWhiteSpace($resolvedDisplayJson) -and -not [string]::IsNullOrWhiteSpace($env:DISPLAY_INFORMATION_JSON)) {
-    $resolvedDisplayJson = $env:DISPLAY_INFORMATION_JSON
-}
-if ([string]::IsNullOrWhiteSpace($resolvedDisplayJson)) {
-    $errorObject = [PSCustomObject]@{
-        error = "DisplayInformationJSON was not provided. Pass -DisplayInformationJSON, -DisplayInformationJsonPath, or set DISPLAY_INFORMATION_JSON."
+
+    # 3a) Ensure build log directory exists for troubleshooting
+    $LogDirectory = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
+        Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/logs"
+    } else {
+        Join-Path -Path $artifactRoot -ChildPath "builds/logs"
     }
-    $errorObject | ConvertTo-Json -Depth 10
-    exit 1
-}
+    New-Item -ItemType Directory -Path $LogDirectory -Force | Out-Null
 
-try {
-    $jsonObj = $resolvedDisplayJson | ConvertFrom-Json
-}
-catch {
-    $errorObject = [PSCustomObject]@{
-        error      = "Failed to parse DisplayInformation JSON."
-        exception  = $_.Exception.Message
-        stackTrace = $_.Exception.StackTrace
-    }
-    $errorObject | ConvertTo-Json -Depth 10
-    exit 1
-}
-
-# If "Package Version" doesn't exist, create it as a subobject
-if (-not $jsonObj.'Package Version') {
-    $jsonObj | Add-Member -MemberType NoteProperty -Name 'Package Version' -Value ([PSCustomObject]@{
-        major = $Major
-        minor = $Minor
-        patch = $Patch
-        build = $Build
-    })
-}
-else {
-    # "Package Version" exists, so just overwrite its fields
-    $jsonObj.'Package Version'.major = $Major
-    $jsonObj.'Package Version'.minor = $Minor
-    $jsonObj.'Package Version'.patch = $Patch
-    $jsonObj.'Package Version'.build = $Build
-}
-
-# 5a) Pre-clean existing VIP in the configured output folder to avoid VIPM error 10
-$vipBaseName = if (-not [string]::IsNullOrWhiteSpace($packageFileName)) {
-    $packageFileName
-} else {
-    [System.IO.Path]::GetFileNameWithoutExtension($ResolvedVIPBPath)
-}
-$vipVersion = "$Major.$Minor.$Patch.$Build"
-$vipName = "{0}-{1}.vip" -f $vipBaseName, $vipVersion
-$outputDirToClean = if (-not [string]::IsNullOrWhiteSpace($vipbOutputDir)) { $vipbOutputDir } else { $vipOutputDir }
-if (-not (Test-Path -Path $outputDirToClean)) {
-    New-Item -ItemType Directory -Path $outputDirToClean -Force | Out-Null
-}
-$vipFullPath = Join-Path -Path $outputDirToClean -ChildPath $vipName
-if (Test-Path -Path $vipFullPath) {
-    Write-Host ("Removing existing VIP to avoid overwrite error: {0}" -f $vipFullPath)
-    Remove-Item -Path $vipFullPath -Force -ErrorAction SilentlyContinue
-}
-
-# 6) Construct reusable VIPM CLI arguments
-$vipmCommand = Get-Command vipm -ErrorAction SilentlyContinue
-if (-not $vipmCommand) {
-    $errorObject = [PSCustomObject]@{
-        error = "VIPM CLI is not available on PATH."
-    }
-    $errorObject | ConvertTo-Json -Depth 10
-    exit 1
-}
-
-$vipmArgs = @(
-    '--labview-version', $resolvedExecutionLabVIEWYear.ToString(),
-    '--labview-bitness', $SupportedBitness,
-    'build',
-    $ResolvedVIPBPath
-)
-
-$prettyCommand = "{0} {1}" -f $vipmCommand.Source, ($vipmArgs -join ' ')
-Write-Output "Base build command:"
-Write-Output $prettyCommand
-Write-Output ("Release notes source: {0}" -f $ResolvedReleaseNotesFile)
-Write-Output ("Build metadata: version={0}.{1}.{2}.{3} commit={4}" -f $Major, $Minor, $Patch, $Build, $Commit)
-
-# 6a) Keep VIPM target connection settings aligned with strict LabVIEWCLI contract.
-Set-VipmTargetSettingsFromContract `
-    -RepoRoot $ResolvedRepoRoot `
-    -VersionYear $resolvedExecutionLabVIEWYear.ToString() `
-    -MinorRevision $LabVIEWMinorRevision `
-    -Bitness $SupportedBitness `
-    -ConnectionTimeoutSeconds $VipmTimeoutSeconds
-
-# 7) Execute the command once with log capture
-$logFile = Join-Path -Path $LogDirectory -ChildPath "vipm-build.log"
-Write-Host "Starting VIPM CLI build. Logs: $logFile"
-
-$runnerHelper = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\GcliRunner.ps1'
-if (-not (Test-Path -Path $runnerHelper -PathType Leaf)) {
-    $errorObject = [PSCustomObject]@{
-        error = "Command runner helper not found at $runnerHelper."
-    }
-    $errorObject | ConvertTo-Json -Depth 10
-    exit 1
-}
-
-. $runnerHelper
-
-$timeoutMs = [int]([Math]::Min([long]$VipmTimeoutSeconds * 1000, 2147483647))
-$commandResult = Invoke-GCliCommand -ExecutablePath $vipmCommand.Source -Arguments $vipmArgs -TimeoutMs $timeoutMs
-$combinedOutput = @()
-if ($commandResult.OutputLines) {
-    $combinedOutput += @($commandResult.OutputLines)
-}
-if ($commandResult.ErrorLines) {
-    $combinedOutput += @($commandResult.ErrorLines)
-}
-if ($combinedOutput.Count -gt 0) {
-    $combinedOutput | Set-Content -Path $logFile -Encoding utf8
-} else {
-    '' | Set-Content -Path $logFile -Encoding utf8
-}
-
-$effectiveExitCode = if ($commandResult.TimedOut) { 124 } else { [int]$commandResult.ExitCode }
-if ($commandResult.TimedOut) {
-    $timeoutLine = ("Timeout waiting on VIPM after {0} seconds." -f $VipmTimeoutSeconds)
-    Add-Content -Path $logFile -Value $timeoutLine
-    Write-Warning $timeoutLine
-}
-
-if ($effectiveExitCode -ne 0) {
-    if (Test-Path $logFile) {
-        Write-Host ("---- VIPM CLI build log ({0}) ----" -f $logFile)
-        Get-Content -Path $logFile | ForEach-Object { Write-Host $_ }
-        Write-Host ("---- end VIPM CLI build log ----")
+    # 3) Calculate the LabVIEW version string
+    $lvNumericMajor    = $LabVIEWVersion - 2000
+    $lvNumericVersion  = "$($lvNumericMajor).$LabVIEWMinorRevision"
+    if ($SupportedBitness -eq "64") {
+        $VIP_LVVersion_A = "$lvNumericVersion (64-bit)"
     }
     else {
-        Write-Host ("VIPM CLI build log not found at {0}" -f $logFile)
+        $VIP_LVVersion_A = $lvNumericVersion
+    }
+    Write-Output "Building VI Package for LabVIEW $VIP_LVVersion_A..."
+
+    # 4) Resolve and parse DisplayInformation JSON
+    $resolvedDisplayJson = $DisplayInformationJSON
+    if ([string]::IsNullOrWhiteSpace($resolvedDisplayJson) -and -not [string]::IsNullOrWhiteSpace($DisplayInformationJsonPath)) {
+        if (-not (Test-Path -Path $DisplayInformationJsonPath)) {
+            $errorObject = [PSCustomObject]@{
+                error      = "DisplayInformationJsonPath '$DisplayInformationJsonPath' does not exist."
+            }
+            $errorObject | ConvertTo-Json -Depth 10
+            exit 1
+        }
+        $resolvedDisplayJson = Get-Content -Raw -Path $DisplayInformationJsonPath
+    }
+    if ([string]::IsNullOrWhiteSpace($resolvedDisplayJson) -and -not [string]::IsNullOrWhiteSpace($env:DISPLAY_INFORMATION_JSON)) {
+        $resolvedDisplayJson = $env:DISPLAY_INFORMATION_JSON
+    }
+    if ([string]::IsNullOrWhiteSpace($resolvedDisplayJson)) {
+        $errorObject = [PSCustomObject]@{
+            error = "DisplayInformationJSON was not provided. Pass -DisplayInformationJSON, -DisplayInformationJsonPath, or set DISPLAY_INFORMATION_JSON."
+        }
+        $errorObject | ConvertTo-Json -Depth 10
+        exit 1
+    }
+
+    try {
+        $jsonObj = $resolvedDisplayJson | ConvertFrom-Json
+    }
+    catch {
+        $errorObject = [PSCustomObject]@{
+            error      = "Failed to parse DisplayInformation JSON."
+            exception  = $_.Exception.Message
+            stackTrace = $_.Exception.StackTrace
+        }
+        $errorObject | ConvertTo-Json -Depth 10
+        exit 1
+    }
+
+    # If "Package Version" doesn't exist, create it as a subobject
+    if (-not $jsonObj.'Package Version') {
+        $jsonObj | Add-Member -MemberType NoteProperty -Name 'Package Version' -Value ([PSCustomObject]@{
+            major = $Major
+            minor = $Minor
+            patch = $Patch
+            build = $Build
+        })
+    }
+    else {
+        # "Package Version" exists, so just overwrite its fields
+        $jsonObj.'Package Version'.major = $Major
+        $jsonObj.'Package Version'.minor = $Minor
+        $jsonObj.'Package Version'.patch = $Patch
+        $jsonObj.'Package Version'.build = $Build
+    }
+
+    # Re-convert to a JSON string with a comfortable nesting depth
+    $UpdatedDisplayInformationJSON = $jsonObj | ConvertTo-Json -Depth 5
+
+    # 5a) Pre-clean existing VIP in the configured output folder to avoid VIPM error 10
+    $vipBaseName = if (-not [string]::IsNullOrWhiteSpace($packageFileName)) {
+        $packageFileName
+    } else {
+        [System.IO.Path]::GetFileNameWithoutExtension($ResolvedVIPBPath)
+    }
+    $vipVersion = "$Major.$Minor.$Patch.$Build"
+    $vipName = "{0}-{1}.vip" -f $vipBaseName, $vipVersion
+    $outputDirToClean = if (-not [string]::IsNullOrWhiteSpace($vipbOutputDir)) { $vipbOutputDir } else { $vipOutputDir }
+    if (-not (Test-Path -Path $outputDirToClean)) {
+        New-Item -ItemType Directory -Path $outputDirToClean -Force | Out-Null
+    }
+    $vipFullPath = Join-Path -Path $outputDirToClean -ChildPath $vipName
+    if (Test-Path -Path $vipFullPath) {
+        Write-Host ("Removing existing VIP to avoid overwrite error: {0}" -f $vipFullPath)
+        Remove-Item -Path $vipFullPath -Force -ErrorAction SilentlyContinue
+    }
+
+# 6) Update VIPB metadata before packaging (uses PowerShell XML update path)
+$modifyVipbScript = Join-Path -Path $ResolvedRepoRoot -ChildPath '.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1'
+if (-not (Test-Path -Path $modifyVipbScript)) {
+    $errorObject = [PSCustomObject]@{
+        error = "Required script not found."
+        path  = $modifyVipbScript
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+
+$metadataLogFile = Join-Path -Path $LogDirectory -ChildPath "vipb-metadata-update.log"
+$modifyArgs = @(
+    '-NoProfile',
+    '-File', $modifyVipbScript,
+    '-SupportedBitness', $SupportedBitness,
+    '-RepoRoot', $ResolvedRepoRoot,
+    '-VIPBPath', $VIPBPath,
+    '-LabVIEWVersion', $LabVIEWVersion.ToString(),
+    '-LabVIEWMinorRevision', $LabVIEWMinorRevision.ToString(),
+    '-Major', $Major.ToString(),
+    '-Minor', $Minor.ToString(),
+    '-Patch', $Patch.ToString(),
+    '-Build', $Build.ToString(),
+    '-Commit', $Commit,
+    '-ReleaseNotesFile', $ResolvedReleaseNotesFile.ToString(),
+    '-DisplayInformationJSON', $UpdatedDisplayInformationJSON
+)
+if (-not [string]::IsNullOrWhiteSpace($WorktreeRoot)) {
+    $modifyArgs += @('-WorktreeRoot', $WorktreeRoot)
+}
+if ($SkipWorktreeRootCheck.IsPresent) {
+    $modifyArgs += '-SkipWorktreeRootCheck'
+}
+
+Write-Host "Updating VIPB metadata before build. Logs: $metadataLogFile"
+try {
+    & pwsh @modifyArgs 2>&1 | Tee-Object -FilePath $metadataLogFile
+}
+catch {
+    $_ | Out-String | Tee-Object -FilePath $metadataLogFile -Append | Out-Null
+    $LASTEXITCODE = 1
+}
+
+if ($LASTEXITCODE -ne 0) {
+    if (Test-Path $metadataLogFile) {
+        Write-Host ("---- VIPB metadata log ({0}) ----" -f $metadataLogFile)
+        Get-Content -Path $metadataLogFile | ForEach-Object { Write-Host $_ }
+        Write-Host ("---- end VIPB metadata log ----")
     }
 
     $errorObject = [PSCustomObject]@{
-        error    = if ($commandResult.TimedOut) { "VIPM CLI build timed out." } else { "VIPM CLI build failed." }
-        exitCode = $effectiveExitCode
+        error    = "VIPB metadata update failed."
+        exitCode = $LASTEXITCODE
+        log      = $metadataLogFile
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+
+# 7) Construct reusable VIPM CLI arguments
+$vipmArgs = @(
+    "--labview-version", $LabVIEWVersion.ToString(),
+    "--labview-bitness", $SupportedBitness,
+    "build", $ResolvedVIPBPath
+)
+
+$prettyCommand = "vipm " + ($vipmArgs -join ' ')
+Write-Output "Build command:"
+Write-Output $prettyCommand
+
+# 8) Execute VIPM build with log capture
+# Keep legacy filename for downstream tooling compatibility.
+$logFile = Join-Path -Path $LogDirectory -ChildPath "gcli-build.log"
+Write-Host "Starting VIPM build. Logs: $logFile"
+
+try {
+    & vipm @vipmArgs 2>&1 | Tee-Object -FilePath $logFile
+}
+catch {
+    $_ | Out-String | Tee-Object -FilePath $logFile -Append | Out-Null
+    $LASTEXITCODE = 1
+}
+
+if ($LASTEXITCODE -ne 0) {
+    if (Test-Path $logFile) {
+        Write-Host ("---- VIPM build log ({0}) ----" -f $logFile)
+        Get-Content -Path $logFile | ForEach-Object { Write-Host $_ }
+        Write-Host ("---- end VIPM build log ----")
+    }
+    else {
+        Write-Host ("VIPM build log not found at {0}" -f $logFile)
+    }
+
+    $errorObject = [PSCustomObject]@{
+        error    = "VIPM build failed."
+        exitCode = $LASTEXITCODE
         log      = $logFile
     }
     $errorObject | ConvertTo-Json -Depth 10
     exit 1
 }
 
-Write-Host "Successfully built VI package: $ResolvedVIPBPath"
+Write-Host "Successfully built VI package from VIPB: $ResolvedVIPBPath"
 
 if (-not [string]::IsNullOrWhiteSpace($artifactRoot)) {
     try {
@@ -750,6 +427,6 @@ if (-not [string]::IsNullOrWhiteSpace($artifactRoot)) {
 }
 finally {
     if (-not [string]::IsNullOrWhiteSpace($vipbBuildLockPath)) {
-        Release-VipbBuildLock -LockPath $vipbBuildLockPath
+        Remove-VipbBuildLockLease -LockPath $vipbBuildLockPath
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,6 +837,87 @@ jobs:
           create_worktree: 'true'
           worktree_root_mode: runner_temp
       - name: Audit VIPC apply (LV x64)
+        id: vipc_audit
+        shell: pwsh
+        working-directory: ${{ env.REPO_ROOT }}
+        run: |
+          $runnerCliProject = Join-Path $env:REPO_ROOT 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+          if (-not (Test-Path -Path $runnerCliProject -PathType Leaf)) {
+            throw "runner-cli project not found at $runnerCliProject"
+          }
+
+          $auditPath = "$env:REPO_ROOT\\builds\\status\\vipc-audit-64.json"
+          $runnerCliArgs = @(
+            'vipc', 'assert',
+            '--repo-root', $env:REPO_ROOT,
+            '--supported-bitness', '64',
+            '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
+            '--output-path', $auditPath,
+            '--fail-on-mismatch', 'false'
+          )
+          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          if (-not (Test-Path -LiteralPath $auditPath -PathType Leaf)) {
+            throw "VIPC audit report was not produced at $auditPath"
+          }
+
+          $auditReport = Get-Content -LiteralPath $auditPath -Raw | ConvertFrom-Json
+          $mismatchCount = [int]$auditReport.summary.mismatched_roots
+          Write-Host ("VIPC audit mismatch roots (64-bit): {0}" -f $mismatchCount)
+
+          "vipc_audit_path=$auditPath" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "vipc_mismatch_count=$mismatchCount" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+      - name: Report VIPC change status (LV x64)
+        shell: pwsh
+        run: |
+          if ('${{ steps.vipc_audit.outputs.vipc_mismatch_count }}' -ne '0') {
+            Write-Warning "VIPC drift detected for LV x64; remediation step will run."
+          } elseif ('${{ needs.changes.outputs.vipc }}' -eq 'true') {
+            Write-Host ".vipc changes detected for this run."
+          } else {
+            Write-Host "No .vipc changes detected; audit-first policy still enforced."
+          }
+      - name: Apply VIPC remediation (LV x64)
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        shell: pwsh
+        working-directory: ${{ env.REPO_ROOT }}
+        run: |
+          $runnerCliProject = Join-Path $env:REPO_ROOT 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+          if (-not (Test-Path -Path $runnerCliProject -PathType Leaf)) {
+            throw "runner-cli project not found at $runnerCliProject"
+          }
+
+          $logPath = Join-Path $env:REPO_ROOT 'builds\status\vipc-remediate-64.log'
+          $logDir = Split-Path -Path $logPath -Parent
+          if (-not (Test-Path -Path $logDir)) {
+            New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+          }
+
+          '' | Set-Content -Path $logPath -Encoding utf8
+          $runnerCliArgs = @(
+            'vipc', 'apply',
+            '--repo-root', $env:REPO_ROOT,
+            '--supported-bitness', '64',
+            '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
+          )
+          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $exitCode = $LASTEXITCODE
+
+          if ($output) {
+            $output |
+              ForEach-Object { $_.ToString() } |
+              Tee-Object -FilePath $logPath -Append |
+              ForEach-Object { Write-Host $_ }
+          }
+
+          if ($exitCode -ne 0) {
+            exit $exitCode
+          }
+      - name: Re-audit VIPC apply (LV x64)
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
@@ -850,19 +931,71 @@ jobs:
             '--repo-root', $env:REPO_ROOT,
             '--supported-bitness', '64',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
-            '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-64.json"
+            '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-post-64.json"
           )
           & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
-      - name: Report VIPC change status (LV x64)
-        shell: pwsh
-        run: |
-          if ('${{ needs.changes.outputs.vipc }}' -eq 'true') {
-            Write-Host ".vipc changes detected for this run."
-          } else {
-            Write-Host "No .vipc changes detected; audit-first policy still enforced."
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
           }
+      - name: VIPC remediation summary (LV x64)
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        shell: pwsh
+        working-directory: ${{ env.REPO_ROOT }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+            Write-Host "GITHUB_STEP_SUMMARY not available; skipping remediation summary."
+            exit 0
+          }
+
+          $beforePath = Join-Path $env:REPO_ROOT 'builds\status\vipc-audit-64.json'
+          $afterPath = Join-Path $env:REPO_ROOT 'builds\status\vipc-audit-post-64.json'
+          if (-not (Test-Path -LiteralPath $beforePath -PathType Leaf)) {
+            throw "Pre-remediation VIPC audit report not found at $beforePath"
+          }
+          if (-not (Test-Path -LiteralPath $afterPath -PathType Leaf)) {
+            throw "Post-remediation VIPC audit report not found at $afterPath"
+          }
+
+          $before = Get-Content -LiteralPath $beforePath -Raw | ConvertFrom-Json
+          $after = Get-Content -LiteralPath $afterPath -Raw | ConvertFrom-Json
+          $beforeMismatched = @($before.root_audit | Where-Object { -not $_.matched })
+          $afterMismatched = @($after.root_audit | Where-Object { -not $_.matched })
+
+          $remediatedPackages = New-Object System.Collections.Generic.List[string]
+          foreach ($beforeRoot in $beforeMismatched) {
+            $afterRoot = $after.root_audit | Where-Object { $_.root -eq $beforeRoot.root } | Select-Object -First 1
+            if ($null -eq $afterRoot -or -not $afterRoot.matched) {
+              continue
+            }
+            foreach ($pkg in @($beforeRoot.missing_expected + $beforeRoot.unexpected_installed)) {
+              if (-not [string]::IsNullOrWhiteSpace($pkg)) {
+                $remediatedPackages.Add([string]$pkg) | Out-Null
+              }
+            }
+          }
+
+          $uniqueRemediated = @($remediatedPackages | Sort-Object -Unique)
+          $lines = @(
+            '### VIPC Remediation (LV x64)'
+            ("- Before mismatched roots: {0}" -f $beforeMismatched.Count)
+            ("- After mismatched roots: {0}" -f $afterMismatched.Count)
+            ("- Remediated package entries: {0}" -f $uniqueRemediated.Count)
+          )
+          if ($uniqueRemediated.Count -gt 0) {
+            $lines += ''
+            $lines += '- Remediated packages:'
+            $maxRows = [Math]::Min($uniqueRemediated.Count, 25)
+            for ($i = 0; $i -lt $maxRows; $i++) {
+              $lines += ("  - `{0}`" -f $uniqueRemediated[$i])
+            }
+            if ($uniqueRemediated.Count -gt $maxRows) {
+              $lines += ("  - ... and {0} more" -f ($uniqueRemediated.Count - $maxRows))
+            }
+          }
+
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($lines -join [Environment]::NewLine)
       - name: Apply VIPC (LV x64, informational)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count == '0' && github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
         continue-on-error: true
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
@@ -905,8 +1038,22 @@ jobs:
           name: vipc-audit-64
           path: ${{ env.REPO_ROOT }}/builds/status/vipc-audit-64.json
           if-no-files-found: warn
+      - name: Upload VIPC post-remediation audit artifact (LV x64)
+        if: ${{ always() && steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vipc-audit-post-64
+          path: ${{ env.REPO_ROOT }}/builds/status/vipc-audit-post-64.json
+          if-no-files-found: warn
+      - name: Upload VIPC remediation log artifact (LV x64)
+        if: ${{ always() && steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vipc-remediate-log-64
+          path: ${{ env.REPO_ROOT }}/builds/status/vipc-remediate-64.log
+          if-no-files-found: warn
       - name: Upload VIPC apply log artifact (LV x64)
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
+        if: ${{ always() && steps.vipc_audit.outputs.vipc_mismatch_count == '0' && github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: vipc-apply-log-64
@@ -938,6 +1085,87 @@ jobs:
           create_worktree: 'true'
           worktree_root_mode: runner_temp
       - name: Audit VIPC apply (LV x86)
+        id: vipc_audit
+        shell: pwsh
+        working-directory: ${{ env.REPO_ROOT }}
+        run: |
+          $runnerCliProject = Join-Path $env:REPO_ROOT 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+          if (-not (Test-Path -Path $runnerCliProject -PathType Leaf)) {
+            throw "runner-cli project not found at $runnerCliProject"
+          }
+
+          $auditPath = "$env:REPO_ROOT\\builds\\status\\vipc-audit-32.json"
+          $runnerCliArgs = @(
+            'vipc', 'assert',
+            '--repo-root', $env:REPO_ROOT,
+            '--supported-bitness', '32',
+            '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
+            '--output-path', $auditPath,
+            '--fail-on-mismatch', 'false'
+          )
+          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          if (-not (Test-Path -LiteralPath $auditPath -PathType Leaf)) {
+            throw "VIPC audit report was not produced at $auditPath"
+          }
+
+          $auditReport = Get-Content -LiteralPath $auditPath -Raw | ConvertFrom-Json
+          $mismatchCount = [int]$auditReport.summary.mismatched_roots
+          Write-Host ("VIPC audit mismatch roots (32-bit): {0}" -f $mismatchCount)
+
+          "vipc_audit_path=$auditPath" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          "vipc_mismatch_count=$mismatchCount" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+      - name: Report VIPC change status (LV x86)
+        shell: pwsh
+        run: |
+          if ('${{ steps.vipc_audit.outputs.vipc_mismatch_count }}' -ne '0') {
+            Write-Warning "VIPC drift detected for LV x86; remediation step will run."
+          } elseif ('${{ needs.changes.outputs.vipc }}' -eq 'true') {
+            Write-Host ".vipc changes detected for this run."
+          } else {
+            Write-Host "No .vipc changes detected; audit-first policy still enforced."
+          }
+      - name: Apply VIPC remediation (LV x86)
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        shell: pwsh
+        working-directory: ${{ env.REPO_ROOT }}
+        run: |
+          $runnerCliProject = Join-Path $env:REPO_ROOT 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+          if (-not (Test-Path -Path $runnerCliProject -PathType Leaf)) {
+            throw "runner-cli project not found at $runnerCliProject"
+          }
+
+          $logPath = Join-Path $env:REPO_ROOT 'builds\status\vipc-remediate-32.log'
+          $logDir = Split-Path -Path $logPath -Parent
+          if (-not (Test-Path -Path $logDir)) {
+            New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+          }
+
+          '' | Set-Content -Path $logPath -Encoding utf8
+          $runnerCliArgs = @(
+            'vipc', 'apply',
+            '--repo-root', $env:REPO_ROOT,
+            '--supported-bitness', '32',
+            '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
+          )
+          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $exitCode = $LASTEXITCODE
+
+          if ($output) {
+            $output |
+              ForEach-Object { $_.ToString() } |
+              Tee-Object -FilePath $logPath -Append |
+              ForEach-Object { Write-Host $_ }
+          }
+
+          if ($exitCode -ne 0) {
+            exit $exitCode
+          }
+      - name: Re-audit VIPC apply (LV x86)
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
@@ -951,19 +1179,71 @@ jobs:
             '--repo-root', $env:REPO_ROOT,
             '--supported-bitness', '32',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
-            '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-32.json"
+            '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-post-32.json"
           )
           & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
-      - name: Report VIPC change status (LV x86)
-        shell: pwsh
-        run: |
-          if ('${{ needs.changes.outputs.vipc }}' -eq 'true') {
-            Write-Host ".vipc changes detected for this run."
-          } else {
-            Write-Host "No .vipc changes detected; audit-first policy still enforced."
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
           }
+      - name: VIPC remediation summary (LV x86)
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        shell: pwsh
+        working-directory: ${{ env.REPO_ROOT }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+            Write-Host "GITHUB_STEP_SUMMARY not available; skipping remediation summary."
+            exit 0
+          }
+
+          $beforePath = Join-Path $env:REPO_ROOT 'builds\status\vipc-audit-32.json'
+          $afterPath = Join-Path $env:REPO_ROOT 'builds\status\vipc-audit-post-32.json'
+          if (-not (Test-Path -LiteralPath $beforePath -PathType Leaf)) {
+            throw "Pre-remediation VIPC audit report not found at $beforePath"
+          }
+          if (-not (Test-Path -LiteralPath $afterPath -PathType Leaf)) {
+            throw "Post-remediation VIPC audit report not found at $afterPath"
+          }
+
+          $before = Get-Content -LiteralPath $beforePath -Raw | ConvertFrom-Json
+          $after = Get-Content -LiteralPath $afterPath -Raw | ConvertFrom-Json
+          $beforeMismatched = @($before.root_audit | Where-Object { -not $_.matched })
+          $afterMismatched = @($after.root_audit | Where-Object { -not $_.matched })
+
+          $remediatedPackages = New-Object System.Collections.Generic.List[string]
+          foreach ($beforeRoot in $beforeMismatched) {
+            $afterRoot = $after.root_audit | Where-Object { $_.root -eq $beforeRoot.root } | Select-Object -First 1
+            if ($null -eq $afterRoot -or -not $afterRoot.matched) {
+              continue
+            }
+            foreach ($pkg in @($beforeRoot.missing_expected + $beforeRoot.unexpected_installed)) {
+              if (-not [string]::IsNullOrWhiteSpace($pkg)) {
+                $remediatedPackages.Add([string]$pkg) | Out-Null
+              }
+            }
+          }
+
+          $uniqueRemediated = @($remediatedPackages | Sort-Object -Unique)
+          $lines = @(
+            '### VIPC Remediation (LV x86)'
+            ("- Before mismatched roots: {0}" -f $beforeMismatched.Count)
+            ("- After mismatched roots: {0}" -f $afterMismatched.Count)
+            ("- Remediated package entries: {0}" -f $uniqueRemediated.Count)
+          )
+          if ($uniqueRemediated.Count -gt 0) {
+            $lines += ''
+            $lines += '- Remediated packages:'
+            $maxRows = [Math]::Min($uniqueRemediated.Count, 25)
+            for ($i = 0; $i -lt $maxRows; $i++) {
+              $lines += ("  - `{0}`" -f $uniqueRemediated[$i])
+            }
+            if ($uniqueRemediated.Count -gt $maxRows) {
+              $lines += ("  - ... and {0} more" -f ($uniqueRemediated.Count - $maxRows))
+            }
+          }
+
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($lines -join [Environment]::NewLine)
       - name: Apply VIPC (LV x86, informational)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
+        if: ${{ steps.vipc_audit.outputs.vipc_mismatch_count == '0' && github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
         continue-on-error: true
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
@@ -1006,8 +1286,22 @@ jobs:
           name: vipc-audit-32
           path: ${{ env.REPO_ROOT }}/builds/status/vipc-audit-32.json
           if-no-files-found: warn
+      - name: Upload VIPC post-remediation audit artifact (LV x86)
+        if: ${{ always() && steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vipc-audit-post-32
+          path: ${{ env.REPO_ROOT }}/builds/status/vipc-audit-post-32.json
+          if-no-files-found: warn
+      - name: Upload VIPC remediation log artifact (LV x86)
+        if: ${{ always() && steps.vipc_audit.outputs.vipc_mismatch_count != '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vipc-remediate-log-32
+          path: ${{ env.REPO_ROOT }}/builds/status/vipc-remediate-32.log
+          if-no-files-found: warn
       - name: Upload VIPC apply log artifact (LV x86)
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
+        if: ${{ always() && steps.vipc_audit.outputs.vipc_mismatch_count == '0' && github.event_name == 'workflow_dispatch' && github.event.inputs.vipc_apply_info == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: vipc-apply-log-32

--- a/Test/BuildVipLockContract.Tests.ps1
+++ b/Test/BuildVipLockContract.Tests.ps1
@@ -1,0 +1,53 @@
+Describe "Build VIP lock contract" {
+    BeforeAll {
+        function Find-RepoRoot {
+            param([string]$StartPath)
+
+            $dir = $StartPath
+            while ($dir -and (Test-Path -Path $dir)) {
+                if ((Test-Path (Join-Path $dir ".git")) -or (Test-Path (Join-Path $dir ".lvversion"))) {
+                    return (Resolve-Path -Path $dir).Path
+                }
+
+                $parent = Split-Path -Parent $dir
+                if ($parent -eq $dir) {
+                    break
+                }
+                $dir = $parent
+            }
+
+            throw "Unable to locate repository root from '$StartPath'."
+        }
+
+        $script:repoRoot = Find-RepoRoot -StartPath $PSScriptRoot
+        $script:buildVipScript = Join-Path $script:repoRoot ".github/actions/build-vip/build_vip.ps1"
+        $script:buildVipAction = Join-Path $script:repoRoot ".github/actions/build-vip/action.yml"
+    }
+
+    It "keeps build_vip syntax valid" {
+        $null = $tokens = $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:buildVipScript, [ref]$tokens, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It "sources the shared VIPB lock support script" {
+        $content = Get-Content -Path $script:buildVipScript -Raw
+        $content | Should -Match "Tooling\\support\\VipbBuildLock\.ps1"
+        $content | Should -Match "Acquire-VipbBuildLock"
+        $content | Should -Match "Release-VipbBuildLock"
+
+        $sourceIndex = $content.IndexOf(". `$vipbLockSupportScript")
+        $acquireIndex = $content.IndexOf("Acquire-VipbBuildLock")
+        $sourceIndex | Should -BeGreaterThan -1
+        $acquireIndex | Should -BeGreaterThan -1
+        $sourceIndex | Should -BeLessThan $acquireIndex
+    }
+
+    It "exposes lock controls in the composite action inputs and invocation" {
+        $actionContent = Get-Content -Path $script:buildVipAction -Raw
+        $actionContent | Should -Match "vipb_build_lock_timeout_seconds"
+        $actionContent | Should -Match "vipb_build_lock_stale_seconds"
+        $actionContent | Should -Match "-VipbBuildLockTimeoutSeconds"
+        $actionContent | Should -Match "-VipbBuildLockStaleSeconds"
+    }
+}

--- a/Test/BuildVipLockContract.Tests.ps1
+++ b/Test/BuildVipLockContract.Tests.ps1
@@ -33,11 +33,11 @@ Describe "Build VIP lock contract" {
     It "sources the shared VIPB lock support script" {
         $content = Get-Content -Path $script:buildVipScript -Raw
         $content | Should -Match "Tooling\\support\\VipbBuildLock\.ps1"
-        $content | Should -Match "Acquire-VipbBuildLock"
-        $content | Should -Match "Release-VipbBuildLock"
+        $content | Should -Match "New-VipbBuildLockLease"
+        $content | Should -Match "Remove-VipbBuildLockLease"
 
         $sourceIndex = $content.IndexOf(". `$vipbLockSupportScript")
-        $acquireIndex = $content.IndexOf("Acquire-VipbBuildLock")
+        $acquireIndex = $content.IndexOf("New-VipbBuildLockLease")
         $sourceIndex | Should -BeGreaterThan -1
         $acquireIndex | Should -BeGreaterThan -1
         $sourceIndex | Should -BeLessThan $acquireIndex

--- a/Test/Pester/Run-Pester.ps1
+++ b/Test/Pester/Run-Pester.ps1
@@ -87,7 +87,8 @@ $configuration = New-PesterConfiguration
 $additionalContractTests = @(
     (Join-Path $repoRoot 'Test\BuildVipLockContract.Tests.ps1'),
     (Join-Path $repoRoot 'Test\VipbBuildLock.Tests.ps1'),
-    (Join-Path $repoRoot 'Test\VipmPortAlignment.Tests.ps1')
+    (Join-Path $repoRoot 'Test\VipmPortAlignment.Tests.ps1'),
+    (Join-Path $repoRoot 'Test\VipcRemediationSummaryContract.Tests.ps1')
 ) | Where-Object { Test-Path -Path $_ }
 $configuration.Run.Path = @($PSScriptRoot) + $additionalContractTests
 $configuration.Run.PassThru = $true

--- a/Test/Pester/Run-Pester.ps1
+++ b/Test/Pester/Run-Pester.ps1
@@ -68,7 +68,7 @@ if (Test-Path -Path $versionHelper) {
     $env:LABVIEW_MINOR_REVISION = $versionInfo.MinorRevision.ToString()
     $env:LABVIEW_NUMERIC_VERSION = $versionInfo.NumericVersion
 } elseif ([string]::IsNullOrWhiteSpace($LabVIEWVersion)) {
-    $LabVIEWVersion = '2020'
+    $LabVIEWVersion = '2021'
 }
 
 $env:LABVIEW_VERSION = $LabVIEWVersion
@@ -83,18 +83,11 @@ if ($PSBoundParameters.ContainsKey('RunDevModeTests')) {
     }
 }
 
-$pesterBootstrapPath = Join-Path $repoRoot 'Tooling\support\PesterBootstrap.ps1'
-if (-not (Test-Path -LiteralPath $pesterBootstrapPath -PathType Leaf)) {
-    throw "Pester bootstrap helper not found: $pesterBootstrapPath"
-}
-. $pesterBootstrapPath
-$pesterInfo = Import-RepoPester -RepoRoot $repoRoot -MinimumVersion ([version]'5.0.0') -AllowInstallFromGallery
-Write-Host ("Using Pester {0} from {1}" -f $pesterInfo.Version, $pesterInfo.ModuleBase)
-
 $configuration = New-PesterConfiguration
 $additionalContractTests = @(
     (Join-Path $repoRoot 'Test\BuildVipLockContract.Tests.ps1'),
-    (Join-Path $repoRoot 'Test\VipbBuildLock.Tests.ps1')
+    (Join-Path $repoRoot 'Test\VipbBuildLock.Tests.ps1'),
+    (Join-Path $repoRoot 'Test\VipmPortAlignment.Tests.ps1')
 ) | Where-Object { Test-Path -Path $_ }
 $configuration.Run.Path = @($PSScriptRoot) + $additionalContractTests
 $configuration.Run.PassThru = $true
@@ -106,23 +99,9 @@ if ($CI) {
         New-Item -Path $resultsDir -ItemType Directory | Out-Null
     }
 
-    $pesterRunTokenParts = @()
-    if (-not [string]::IsNullOrWhiteSpace($RunId)) {
-        $sanitizedRunId = ($RunId -replace '[^A-Za-z0-9._-]', '-')
-        if (-not [string]::IsNullOrWhiteSpace($sanitizedRunId)) {
-            $pesterRunTokenParts += $sanitizedRunId
-        }
-    }
-    $pesterRunTokenTimestamp = Get-Date -Format 'yyyyMMdd-HHmmss-fff'
-    $pesterRunTokenParts += $LabVIEWVersion
-    $pesterRunTokenParts += $LabVIEWBitness
-    $pesterRunTokenParts += $pesterRunTokenTimestamp
-    $pesterRunTokenParts += $PID
-    $pesterRunToken = ($pesterRunTokenParts -join '-')
-
     $configuration.TestResult.Enabled = $true
     $configuration.TestResult.OutputFormat = 'NUnitXml'
-    $configuration.TestResult.OutputPath = (Join-Path $resultsDir ("pester-devmode-{0}.xml" -f $pesterRunToken))
+    $configuration.TestResult.OutputPath = (Join-Path $resultsDir ("pester-devmode-$LabVIEWVersion-$LabVIEWBitness.xml"))
 }
 
 $exitCode = 0

--- a/Test/Pester/Run-Pester.ps1
+++ b/Test/Pester/Run-Pester.ps1
@@ -92,7 +92,11 @@ $pesterInfo = Import-RepoPester -RepoRoot $repoRoot -MinimumVersion ([version]'5
 Write-Host ("Using Pester {0} from {1}" -f $pesterInfo.Version, $pesterInfo.ModuleBase)
 
 $configuration = New-PesterConfiguration
-$configuration.Run.Path = $PSScriptRoot
+$additionalContractTests = @(
+    (Join-Path $repoRoot 'Test\BuildVipLockContract.Tests.ps1'),
+    (Join-Path $repoRoot 'Test\VipbBuildLock.Tests.ps1')
+) | Where-Object { Test-Path -Path $_ }
+$configuration.Run.Path = @($PSScriptRoot) + $additionalContractTests
 $configuration.Run.PassThru = $true
 $configuration.Output.Verbosity = 'Detailed'
 

--- a/Test/VipbBuildLock.Tests.ps1
+++ b/Test/VipbBuildLock.Tests.ps1
@@ -1,0 +1,137 @@
+Describe "VipbBuildLock support module" {
+    BeforeAll {
+        function Find-RepoRoot {
+            param([string]$StartPath)
+
+            $dir = $StartPath
+            while ($dir -and (Test-Path -Path $dir)) {
+                if ((Test-Path (Join-Path $dir ".git")) -or (Test-Path (Join-Path $dir ".lvversion"))) {
+                    return (Resolve-Path -Path $dir).Path
+                }
+
+                $parent = Split-Path -Parent $dir
+                if ($parent -eq $dir) {
+                    break
+                }
+                $dir = $parent
+            }
+
+            throw "Unable to locate repository root from '$StartPath'."
+        }
+
+        $script:repoRoot = Find-RepoRoot -StartPath $PSScriptRoot
+        $script:supportPath = Join-Path $script:repoRoot "Tooling/support/VipbBuildLock.ps1"
+        $script:tempRoot = Join-Path $script:repoRoot "Test/tmp/vipb-lock-tests"
+        New-Item -ItemType Directory -Path $script:tempRoot -Force | Out-Null
+        . $script:supportPath
+    }
+
+    AfterAll {
+        if (Test-Path $script:tempRoot) {
+            Remove-Item -Path $script:tempRoot -Recurse -Force
+        }
+    }
+
+    It "parses without syntax errors" {
+        $null = $tokens = $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:supportPath, [ref]$tokens, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It "resolves lock root with LVIE_LOCK_ROOT precedence" {
+        $originalLvieLock = $env:LVIE_LOCK_ROOT
+        $originalRunnerTemp = $env:RUNNER_TEMP
+        $originalTemp = $env:TEMP
+        try {
+            $lvieRoot = Join-Path $script:tempRoot "lvie-lock-root"
+            $runnerTemp = Join-Path $script:tempRoot "runner-temp-root"
+            $tempRoot = Join-Path $script:tempRoot "temp-root"
+            New-Item -ItemType Directory -Path $lvieRoot -Force | Out-Null
+            New-Item -ItemType Directory -Path $runnerTemp -Force | Out-Null
+            New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+            $env:LVIE_LOCK_ROOT = $lvieRoot
+            $env:RUNNER_TEMP = $runnerTemp
+            $env:TEMP = $tempRoot
+
+            $resolved = Get-VipbBuildLockRoot -RepoRoot $script:repoRoot
+            $expected = Join-Path $lvieRoot "vipb-build-locks"
+            [System.IO.Path]::GetFullPath($resolved) | Should -Be ([System.IO.Path]::GetFullPath($expected))
+        }
+        finally {
+            $env:LVIE_LOCK_ROOT = $originalLvieLock
+            $env:RUNNER_TEMP = $originalRunnerTemp
+            $env:TEMP = $originalTemp
+        }
+    }
+
+    It "acquires and releases a per-vipb lock" {
+        $lockRoot = Join-Path $script:tempRoot "acquire-release"
+        New-Item -ItemType Directory -Path $lockRoot -Force | Out-Null
+        $vipbPath = Join-Path $script:tempRoot "fixture.vipb"
+        Set-Content -Path $vipbPath -Value "<vipb/>" -NoNewline
+
+        $lockPath = Acquire-VipbBuildLock -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 5 -StaleSeconds 60 -PollIntervalSeconds 1
+        try {
+            Test-Path $lockPath | Should -BeTrue
+            Test-Path (Join-Path $lockPath "lock.json") | Should -BeTrue
+        }
+        finally {
+            Release-VipbBuildLock -LockPath $lockPath
+        }
+
+        Test-Path $lockPath | Should -BeFalse
+    }
+
+    It "recovers stale lock folders" {
+        $lockRoot = Join-Path $script:tempRoot "stale-recovery"
+        New-Item -ItemType Directory -Path $lockRoot -Force | Out-Null
+        $vipbPath = Join-Path $script:tempRoot "stale.vipb"
+        Set-Content -Path $vipbPath -Value "<vipb/>" -NoNewline
+
+        $lockName = Get-VipbBuildLockName -VipbPath $vipbPath
+        $lockPath = Join-Path $lockRoot $lockName
+        New-Item -ItemType Directory -Path $lockPath -Force | Out-Null
+
+        $staleMeta = [PSCustomObject]@{
+            acquired_at_utc = ([DateTime]::UtcNow.AddHours(-2)).ToString('o')
+            machine         = 'stale-owner'
+            pid             = 1
+            vipb_path       = $vipbPath
+        }
+        $staleMeta | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $lockPath "lock.json") -Encoding UTF8
+
+        $acquiredPath = Acquire-VipbBuildLock -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 5 -StaleSeconds 10 -PollIntervalSeconds 1
+        try {
+            $acquiredPath | Should -Be $lockPath
+            Test-Path (Join-Path $lockPath "lock.json") | Should -BeTrue
+        }
+        finally {
+            Release-VipbBuildLock -LockPath $acquiredPath
+        }
+    }
+
+    It "fails fast on non-stale contention timeout" {
+        $lockRoot = Join-Path $script:tempRoot "timeout-contention"
+        New-Item -ItemType Directory -Path $lockRoot -Force | Out-Null
+        $vipbPath = Join-Path $script:tempRoot "timeout.vipb"
+        Set-Content -Path $vipbPath -Value "<vipb/>" -NoNewline
+
+        $lockName = Get-VipbBuildLockName -VipbPath $vipbPath
+        $lockPath = Join-Path $lockRoot $lockName
+        New-Item -ItemType Directory -Path $lockPath -Force | Out-Null
+        $activeMeta = [PSCustomObject]@{
+            acquired_at_utc = ([DateTime]::UtcNow).ToString('o')
+            machine         = 'active-owner'
+            pid             = 999
+            vipb_path       = $vipbPath
+        }
+        $activeMeta | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $lockPath "lock.json") -Encoding UTF8
+
+        {
+            Acquire-VipbBuildLock -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 2 -StaleSeconds 3600 -PollIntervalSeconds 1
+        } | Should -Throw "*Timed out waiting for VIPB build lock*"
+
+        Remove-Item -Path $lockPath -Recurse -Force
+    }
+}

--- a/Test/VipbBuildLock.Tests.ps1
+++ b/Test/VipbBuildLock.Tests.ps1
@@ -71,13 +71,13 @@ Describe "VipbBuildLock support module" {
         $vipbPath = Join-Path $script:tempRoot "fixture.vipb"
         Set-Content -Path $vipbPath -Value "<vipb/>" -NoNewline
 
-        $lockPath = Acquire-VipbBuildLock -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 5 -StaleSeconds 60 -PollIntervalSeconds 1
+        $lockPath = New-VipbBuildLockLease -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 5 -StaleSeconds 60 -PollIntervalSeconds 1
         try {
             Test-Path $lockPath | Should -BeTrue
             Test-Path (Join-Path $lockPath "lock.json") | Should -BeTrue
         }
         finally {
-            Release-VipbBuildLock -LockPath $lockPath
+            Remove-VipbBuildLockLease -LockPath $lockPath
         }
 
         Test-Path $lockPath | Should -BeFalse
@@ -101,13 +101,13 @@ Describe "VipbBuildLock support module" {
         }
         $staleMeta | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $lockPath "lock.json") -Encoding UTF8
 
-        $acquiredPath = Acquire-VipbBuildLock -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 5 -StaleSeconds 10 -PollIntervalSeconds 1
+        $acquiredPath = New-VipbBuildLockLease -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 5 -StaleSeconds 10 -PollIntervalSeconds 1
         try {
             $acquiredPath | Should -Be $lockPath
             Test-Path (Join-Path $lockPath "lock.json") | Should -BeTrue
         }
         finally {
-            Release-VipbBuildLock -LockPath $acquiredPath
+            Remove-VipbBuildLockLease -LockPath $acquiredPath
         }
     }
 
@@ -129,7 +129,7 @@ Describe "VipbBuildLock support module" {
         $activeMeta | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $lockPath "lock.json") -Encoding UTF8
 
         {
-            Acquire-VipbBuildLock -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 2 -StaleSeconds 3600 -PollIntervalSeconds 1
+            New-VipbBuildLockLease -LockRoot $lockRoot -VipbPath $vipbPath -TimeoutSeconds 2 -StaleSeconds 3600 -PollIntervalSeconds 1
         } | Should -Throw "*Timed out waiting for VIPB build lock*"
 
         Remove-Item -Path $lockPath -Recurse -Force

--- a/Test/VipcRemediationSummaryContract.Tests.ps1
+++ b/Test/VipcRemediationSummaryContract.Tests.ps1
@@ -1,0 +1,50 @@
+Describe "VIPC remediation summary contract" {
+    BeforeAll {
+        function Find-RepoRoot {
+            param([string]$StartPath)
+
+            $dir = $StartPath
+            while ($dir -and (Test-Path -Path $dir)) {
+                if ((Test-Path (Join-Path $dir ".git")) -or (Test-Path (Join-Path $dir ".lvversion"))) {
+                    return (Resolve-Path -Path $dir).Path
+                }
+
+                $parent = Split-Path -Parent $dir
+                if ($parent -eq $dir) {
+                    break
+                }
+                $dir = $parent
+            }
+
+            throw "Unable to locate repository root from '$StartPath'."
+        }
+
+        $script:repoRoot = Find-RepoRoot -StartPath $PSScriptRoot
+        $script:ciWorkflowPath = Join-Path $script:repoRoot ".github/workflows/ci.yml"
+    }
+
+    It "keeps ci.yml present for VIPC remediation contract checks" {
+        Test-Path -Path $script:ciWorkflowPath | Should -BeTrue
+    }
+
+    It "writes step summary only for remediation paths in both bitness lanes" {
+        $content = Get-Content -Path $script:ciWorkflowPath -Raw
+
+        $content | Should -Match "name:\s+VIPC remediation summary \(LV x64\)"
+        $content | Should -Match "name:\s+VIPC remediation summary \(LV x86\)"
+        $content | Should -Match "if:\s+\$\{\{\s*steps\.vipc_audit\.outputs\.vipc_mismatch_count != '0'\s*\}\}"
+        $content | Should -Match "### VIPC Remediation \(LV x64\)"
+        $content | Should -Match "### VIPC Remediation \(LV x86\)"
+        $content | Should -Match '\$env:GITHUB_STEP_SUMMARY'
+    }
+
+    It "enforces re-audit after remediation and audit-first mismatch capture" {
+        $content = Get-Content -Path $script:ciWorkflowPath -Raw
+
+        $content | Should -Match "name:\s+Re-audit VIPC apply \(LV x64\)"
+        $content | Should -Match "name:\s+Re-audit VIPC apply \(LV x86\)"
+        $content | Should -Match "'--fail-on-mismatch', 'false'"
+        $content | Should -Match "vipc-audit-post-64\.json"
+        $content | Should -Match "vipc-audit-post-32\.json"
+    }
+}

--- a/Test/VipmPortAlignment.Tests.ps1
+++ b/Test/VipmPortAlignment.Tests.ps1
@@ -1,0 +1,117 @@
+Describe "VIPM port alignment guard" {
+    BeforeAll {
+        function Find-RepoRoot {
+            param([string]$StartPath)
+
+            $dir = $StartPath
+            while ($dir -and (Test-Path -Path $dir)) {
+                if ((Test-Path (Join-Path $dir ".git")) -or (Test-Path (Join-Path $dir ".lvversion"))) {
+                    return (Resolve-Path -Path $dir).Path
+                }
+
+                $parent = Split-Path -Parent $dir
+                if ($parent -eq $dir) {
+                    break
+                }
+                $dir = $parent
+            }
+
+            throw "Unable to locate repository root from '$StartPath'."
+        }
+
+        function New-VipmFixture {
+            param(
+                [int]$VipmPort,
+                [int]$IniPort
+            )
+
+            $lvRoot = Join-Path -Path $TestDrive -ChildPath 'Program Files (x86)\National Instruments\LabVIEW 2020'
+            New-Item -Path $lvRoot -ItemType Directory -Force | Out-Null
+
+            $labviewExePath = Join-Path -Path $lvRoot -ChildPath 'LabVIEW.exe'
+            New-Item -Path $labviewExePath -ItemType File -Force | Out-Null
+
+            $labviewIniPath = Join-Path -Path $lvRoot -ChildPath 'LabVIEW.ini'
+            @(
+                "server.tcp.port=$IniPort"
+                'server.tcp.enabled=True'
+            ) | Set-Content -Path $labviewIniPath -Encoding ascii
+
+            $settingsPath = Join-Path -Path $TestDrive -ChildPath 'VIPM.Settings.ini'
+            @(
+                '[Targets]'
+                'Versions.<size(s)>="1"'
+                'Versions 0="20.0"'
+                'Locations.<size(s)>="1"'
+                ("Locations 0=""{0}""" -f $labviewExePath)
+                ("Ports=""<size(s)=1> {0}""" -f $VipmPort)
+                'Disabled.<size(s)>="1"'
+                'Disabled 0="FALSE"'
+            ) | Set-Content -Path $settingsPath -Encoding ascii
+
+            return [pscustomobject]@{
+                SettingsPath = $settingsPath
+                LabVIEWExePath = $labviewExePath
+                LabVIEWIniPath = $labviewIniPath
+            }
+        }
+
+        $script:repoRoot = Find-RepoRoot -StartPath $PSScriptRoot
+        $script:guardScript = Join-Path $script:repoRoot 'Tooling\support\VipmPortAlignment.ps1'
+        $script:assertScript = Join-Path $script:repoRoot 'Tooling\Assert-VipmPortAlignment.ps1'
+        $script:buildVipScript = Join-Path $script:repoRoot '.github\actions\build-vip\build_vip.ps1'
+
+        . $script:guardScript
+    }
+
+    It "keeps guard script syntax valid" {
+        $null = $tokens = $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:guardScript, [ref]$tokens, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It "keeps assert wrapper syntax valid" {
+        $null = $tokens = $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:assertScript, [ref]$tokens, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It "enforces VIPM port guard in build_vip.ps1" {
+        $content = Get-Content -Path $script:buildVipScript -Raw
+        $content | Should -Match 'Tooling\\support\\VipmPortAlignment\.ps1'
+        $content | Should -Match 'Test-VipmTargetPortAlignment'
+        $content | Should -Match 'VIPM target port mismatch detected'
+    }
+
+    It "detects mismatched VIPM and LabVIEW ports" {
+        $fixture = New-VipmFixture -VipmPort 3371 -IniPort 3365
+        $result = Test-VipmTargetPortAlignment -SettingsPath $fixture.SettingsPath -LabVIEWVersion 2020 -Bitness 32
+
+        $result.passed | Should -BeFalse
+        $result.mismatch_count | Should -Be 1
+        $result.mismatches[0].reason | Should -Be 'port_mismatch'
+        $result.mismatches[0].vipm_port | Should -Be 3371
+        $result.mismatches[0].labview_port | Should -Be 3365
+    }
+
+    It "repairs mismatched VIPM ports and passes re-check" {
+        $fixture = New-VipmFixture -VipmPort 3371 -IniPort 3365
+        $repair = Repair-VipmTargetPortAlignment -SettingsPath $fixture.SettingsPath -LabVIEWVersion 2020 -Bitness 32
+
+        $repair.changed | Should -BeTrue
+        $repair.after.passed | Should -BeTrue
+        Test-Path -Path $repair.backup_path | Should -BeTrue
+
+        $updatedSettings = Get-Content -Path $fixture.SettingsPath -Raw
+        $updatedSettings | Should -Match 'Ports="<size\(s\)=1> 3365"'
+    }
+
+    It "passes when ports are already aligned" {
+        $fixture = New-VipmFixture -VipmPort 3365 -IniPort 3365
+        $result = Test-VipmTargetPortAlignment -SettingsPath $fixture.SettingsPath -LabVIEWVersion 2020 -Bitness 32
+
+        $result.passed | Should -BeTrue
+        $result.mismatch_count | Should -Be 0
+    }
+}
+

--- a/Tooling/Assert-VipmPortAlignment.ps1
+++ b/Tooling/Assert-VipmPortAlignment.ps1
@@ -1,0 +1,67 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string]$SettingsPath,
+
+    [ValidateRange(2000, 2100)]
+    [int]$LabVIEWVersion,
+
+    [ValidateSet('32', '64', 'both')]
+    [string]$LabVIEWBitness = 'both',
+
+    [switch]$IncludeDisabled,
+
+    [switch]$Fix,
+
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+$supportScript = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\VipmPortAlignment.ps1'
+if (-not (Test-Path -Path $supportScript)) {
+    throw "Support script not found: $supportScript"
+}
+. $supportScript
+
+$args = @{
+    SettingsPath = $SettingsPath
+    Bitness = $LabVIEWBitness
+    IncludeDisabled = $IncludeDisabled
+}
+if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
+    $args.LabVIEWVersion = $LabVIEWVersion
+}
+
+$result = $null
+if ($Fix.IsPresent) {
+    $repair = Repair-VipmTargetPortAlignment @args
+    $result = $repair.after
+    if ($repair.changed) {
+        Write-Host ("Updated VIPM target ports in '{0}' (backup: {1})." -f $result.settings_path, $repair.backup_path)
+    } else {
+        Write-Host 'No VIPM port changes were needed.'
+    }
+} else {
+    $result = Test-VipmTargetPortAlignment @args
+}
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $outputDir = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($outputDir) -and -not (Test-Path -Path $outputDir)) {
+        New-Item -Path $outputDir -ItemType Directory -Force | Out-Null
+    }
+    $result | ConvertTo-Json -Depth 8 | Set-Content -Path $OutputPath -Encoding ascii
+}
+
+if ($result.passed) {
+    Write-Host ("VIPM port alignment check passed. targets={0}" -f $result.evaluated_target_count)
+    exit 0
+}
+
+Write-Error ('VIPM port alignment check failed. mismatches={0}' -f $result.mismatch_count)
+$result.mismatches | ConvertTo-Json -Depth 8 | Write-Host
+exit 1
+

--- a/Tooling/Assert-VipmPortAlignment.ps1
+++ b/Tooling/Assert-VipmPortAlignment.ps1
@@ -26,18 +26,18 @@ if (-not (Test-Path -Path $supportScript)) {
 }
 . $supportScript
 
-$args = @{
+$alignmentArgs = @{
     SettingsPath = $SettingsPath
     Bitness = $LabVIEWBitness
     IncludeDisabled = $IncludeDisabled
 }
 if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
-    $args.LabVIEWVersion = $LabVIEWVersion
+    $alignmentArgs.LabVIEWVersion = $LabVIEWVersion
 }
 
 $result = $null
 if ($Fix.IsPresent) {
-    $repair = Repair-VipmTargetPortAlignment @args
+    $repair = Repair-VipmTargetPortAlignment @alignmentArgs
     $result = $repair.after
     if ($repair.changed) {
         Write-Host ("Updated VIPM target ports in '{0}' (backup: {1})." -f $result.settings_path, $repair.backup_path)
@@ -45,7 +45,7 @@ if ($Fix.IsPresent) {
         Write-Host 'No VIPM port changes were needed.'
     }
 } else {
-    $result = Test-VipmTargetPortAlignment @args
+    $result = Test-VipmTargetPortAlignment @alignmentArgs
 }
 
 if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
@@ -64,4 +64,3 @@ if ($result.passed) {
 Write-Error ('VIPM port alignment check failed. mismatches={0}' -f $result.mismatch_count)
 $result.mismatches | ConvertTo-Json -Depth 8 | Write-Host
 exit 1
-

--- a/Tooling/support/VipbBuildLock.ps1
+++ b/Tooling/support/VipbBuildLock.ps1
@@ -43,7 +43,7 @@ function Get-VipbBuildLockName {
     return "vipb-$hashHex.lock"
 }
 
-function Get-VipbBuildLockMetadata {
+function Get-VipbBuildLockInfo {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -64,7 +64,7 @@ function Get-VipbBuildLockMetadata {
     }
 }
 
-function Acquire-VipbBuildLock {
+function New-VipbBuildLockLease {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -107,7 +107,7 @@ function Acquire-VipbBuildLock {
                 continue
             }
 
-            $metadata = Get-VipbBuildLockMetadata -LockPath $lockPath
+            $metadata = Get-VipbBuildLockInfo -LockPath $lockPath
             $isStale = $false
             if ($null -ne $metadata) {
                 $acquiredAtUtc = $null
@@ -158,7 +158,7 @@ function Acquire-VipbBuildLock {
         Start-Sleep -Seconds $PollIntervalSeconds
     }
 
-    $owner = Get-VipbBuildLockMetadata -LockPath $lockPath
+    $owner = Get-VipbBuildLockInfo -LockPath $lockPath
     $ownerSummary = if ($null -eq $owner) {
         'unknown owner'
     }
@@ -169,7 +169,7 @@ function Acquire-VipbBuildLock {
     throw "Timed out waiting for VIPB build lock '$lockPath' after $TimeoutSeconds seconds. Current owner: $ownerSummary."
 }
 
-function Release-VipbBuildLock {
+function Remove-VipbBuildLockLease {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/Tooling/support/VipbBuildLock.ps1
+++ b/Tooling/support/VipbBuildLock.ps1
@@ -1,0 +1,190 @@
+Set-StrictMode -Version Latest
+
+function Get-VipbBuildLockRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $lockRootBase = if (-not [string]::IsNullOrWhiteSpace($env:LVIE_LOCK_ROOT)) {
+        $env:LVIE_LOCK_ROOT
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+        $env:RUNNER_TEMP
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:TEMP)) {
+        $env:TEMP
+    } else {
+        Join-Path -Path $RepoRoot -ChildPath 'builds\locks'
+    }
+
+    $lockRoot = Join-Path -Path $lockRootBase -ChildPath 'vipb-build-locks'
+    New-Item -ItemType Directory -Path $lockRoot -Force | Out-Null
+    return [System.IO.Path]::GetFullPath($lockRoot)
+}
+
+function Get-VipbBuildLockName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$VipbPath
+    )
+
+    $normalizedPath = [System.IO.Path]::GetFullPath($VipbPath).ToLowerInvariant()
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($normalizedPath)
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $sha256.ComputeHash($bytes)
+    }
+    finally {
+        $sha256.Dispose()
+    }
+
+    $hashHex = [BitConverter]::ToString($hashBytes).Replace('-', '').Substring(0, 16).ToLowerInvariant()
+    return "vipb-$hashHex.lock"
+}
+
+function Get-VipbBuildLockMetadata {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LockPath
+    )
+
+    $metaPath = Join-Path -Path $LockPath -ChildPath 'lock.json'
+    if (-not (Test-Path -Path $metaPath)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -Path $metaPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        Write-Warning ("Failed to parse lock metadata at '{0}': {1}" -f $metaPath, $_.Exception.Message)
+        return $null
+    }
+}
+
+function Acquire-VipbBuildLock {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LockRoot,
+        [Parameter(Mandatory = $true)]
+        [string]$VipbPath,
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, 7200)]
+        [int]$TimeoutSeconds,
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, 86400)]
+        [int]$StaleSeconds,
+        [ValidateRange(1, 30)]
+        [int]$PollIntervalSeconds = 5
+    )
+
+    $lockName = Get-VipbBuildLockName -VipbPath $VipbPath
+    $lockPath = Join-Path -Path $LockRoot -ChildPath $lockName
+    $metaPath = Join-Path -Path $lockPath -ChildPath 'lock.json'
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $hostName = [Environment]::MachineName
+    $pidValue = $PID
+
+    while ((Get-Date) -lt $deadline) {
+        try {
+            New-Item -Path $lockPath -ItemType Directory -ErrorAction Stop | Out-Null
+            $metadata = [PSCustomObject]@{
+                acquired_at_utc = [DateTime]::UtcNow.ToString('o')
+                machine         = $hostName
+                pid             = $pidValue
+                vipb_path       = $VipbPath
+            }
+            $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $metaPath -Encoding UTF8
+            Write-Host ("Acquired VIPB build lock: {0}" -f $lockPath)
+            return $lockPath
+        }
+        catch {
+            if (-not (Test-Path -Path $lockPath)) {
+                Start-Sleep -Seconds ([Math]::Min(2, $PollIntervalSeconds))
+                continue
+            }
+
+            $metadata = Get-VipbBuildLockMetadata -LockPath $lockPath
+            $isStale = $false
+            if ($null -ne $metadata) {
+                $acquiredAtUtc = $null
+                $acquiredValue = $metadata.acquired_at_utc
+                if ($acquiredValue -is [DateTime]) {
+                    $acquiredAtUtc = [DateTime]$acquiredValue
+                    if ($acquiredAtUtc.Kind -eq [DateTimeKind]::Unspecified) {
+                        $acquiredAtUtc = [DateTime]::SpecifyKind($acquiredAtUtc, [DateTimeKind]::Utc)
+                    }
+                }
+                elseif (-not [string]::IsNullOrWhiteSpace([string]$acquiredValue)) {
+                    try {
+                        $acquiredAtUtc = [DateTimeOffset]::Parse(
+                            [string]$acquiredValue,
+                            [System.Globalization.CultureInfo]::InvariantCulture,
+                            [System.Globalization.DateTimeStyles]::AssumeUniversal
+                        ).UtcDateTime
+                    }
+                    catch {
+                        Write-Warning ("Invalid lock timestamp for '{0}': {1}" -f $lockPath, $_.Exception.Message)
+                    }
+                }
+
+                if ($null -eq $acquiredAtUtc) {
+                    # Unparseable timestamps should not block progress forever.
+                    $isStale = $true
+                }
+                else {
+                    $ageSeconds = ([DateTime]::UtcNow - $acquiredAtUtc).TotalSeconds
+                    if ($ageSeconds -ge $StaleSeconds) {
+                        $isStale = $true
+                    }
+                }
+            }
+
+            if ($isStale) {
+                Write-Warning ("Removing stale VIPB build lock '{0}'." -f $lockPath)
+                try {
+                    Remove-Item -Path $lockPath -Recurse -Force -ErrorAction Stop
+                    continue
+                }
+                catch {
+                    Write-Warning ("Failed to remove stale VIPB build lock '{0}': {1}" -f $lockPath, $_.Exception.Message)
+                }
+            }
+        }
+
+        Start-Sleep -Seconds $PollIntervalSeconds
+    }
+
+    $owner = Get-VipbBuildLockMetadata -LockPath $lockPath
+    $ownerSummary = if ($null -eq $owner) {
+        'unknown owner'
+    }
+    else {
+        "{0} (pid={1}, acquired={2})" -f $owner.machine, $owner.pid, $owner.acquired_at_utc
+    }
+
+    throw "Timed out waiting for VIPB build lock '$lockPath' after $TimeoutSeconds seconds. Current owner: $ownerSummary."
+}
+
+function Release-VipbBuildLock {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LockPath
+    )
+
+    if (-not (Test-Path -Path $LockPath)) {
+        return
+    }
+
+    try {
+        Remove-Item -Path $LockPath -Recurse -Force -ErrorAction Stop
+        Write-Host ("Released VIPB build lock: {0}" -f $LockPath)
+    }
+    catch {
+        Write-Warning ("Failed to release VIPB build lock '{0}': {1}" -f $LockPath, $_.Exception.Message)
+    }
+}

--- a/Tooling/support/VipmPortAlignment.ps1
+++ b/Tooling/support/VipmPortAlignment.ps1
@@ -51,7 +51,7 @@ function Convert-VipmPathToWindows {
     return ($Path -replace '/', '\')
 }
 
-function Get-IndexedIniValues {
+function Get-IndexedIniEntryMap {
     [CmdletBinding()]
     param(
         [string[]]$Lines,
@@ -72,7 +72,7 @@ function Get-IndexedIniValues {
     return $map
 }
 
-function Get-VipmPortsFromSettingsLines {
+function Get-VipmPortSpecFromSettingsLine {
     [CmdletBinding()]
     param(
         [string[]]$Lines
@@ -180,7 +180,7 @@ function Get-LabVIEWServerPortFromIni {
     return [int]$match.Groups[1].Value
 }
 
-function Get-VipmTargetsFromSettings {
+function Get-VipmTargetCatalogFromConfig {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -190,10 +190,10 @@ function Get-VipmTargetsFromSettings {
     $resolvedSettingsPath = (Resolve-Path -Path $SettingsPath -ErrorAction Stop).Path
     $lines = Get-Content -Path $resolvedSettingsPath
 
-    $versions = Get-IndexedIniValues -Lines $lines -KeyPrefix 'Versions'
-    $locations = Get-IndexedIniValues -Lines $lines -KeyPrefix 'Locations'
-    $disabledMap = Get-IndexedIniValues -Lines $lines -KeyPrefix 'Disabled'
-    $portsInfo = Get-VipmPortsFromSettingsLines -Lines $lines
+    $versions = Get-IndexedIniEntryMap -Lines $lines -KeyPrefix 'Versions'
+    $locations = Get-IndexedIniEntryMap -Lines $lines -KeyPrefix 'Locations'
+    $disabledMap = Get-IndexedIniEntryMap -Lines $lines -KeyPrefix 'Disabled'
+    $portsInfo = Get-VipmPortSpecFromSettingsLine -Lines $lines
 
     $allIndexes = @()
     $allIndexes += $versions.Keys
@@ -258,7 +258,7 @@ function Test-VipmTargetPortAlignment {
         (Resolve-Path -Path $SettingsPath -ErrorAction Stop).Path
     }
 
-    $targets = Get-VipmTargetsFromSettings -SettingsPath $resolvedSettingsPath
+    $targets = Get-VipmTargetCatalogFromConfig -SettingsPath $resolvedSettingsPath
 
     if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
         $targets = $targets | Where-Object { $_.Year -eq $LabVIEWVersion }
@@ -384,7 +384,7 @@ function Repair-VipmTargetPortAlignment {
     }
 
     $lines = Get-Content -Path $resolvedSettingsPath
-    $portsInfo = Get-VipmPortsFromSettingsLines -Lines $lines
+    $portsInfo = Get-VipmPortSpecFromSettingsLine -Lines $lines
     $ports = @($portsInfo.Ports)
 
     $changedIndexes = @()
@@ -464,16 +464,16 @@ function Assert-VipmTargetPortAlignment {
         [switch]$IncludeDisabled
     )
 
-    $args = @{
+$checkArgs = @{
         SettingsPath = $SettingsPath
         Bitness = $Bitness
         IncludeDisabled = $IncludeDisabled
     }
     if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
-        $args.LabVIEWVersion = $LabVIEWVersion
+        $checkArgs.LabVIEWVersion = $LabVIEWVersion
     }
 
-    $result = Test-VipmTargetPortAlignment @args
+    $result = Test-VipmTargetPortAlignment @checkArgs
     if (-not $result.passed) {
         $payload = $result | ConvertTo-Json -Depth 8
         throw "VIPM target port alignment check failed: $payload"

--- a/Tooling/support/VipmPortAlignment.ps1
+++ b/Tooling/support/VipmPortAlignment.ps1
@@ -1,0 +1,483 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Validates that VIPM target ports match LabVIEW.ini VI Server ports.
+
+.DESCRIPTION
+    Reads VIPM target configuration from Settings.ini and compares each target's
+    configured VIPM port to server.tcp.port in the matching LabVIEW.ini.
+#>
+
+function Get-VipmSettingsPath {
+    [CmdletBinding()]
+    param(
+        [string]$ProgramDataPath = $env:ProgramData
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ProgramDataPath)) {
+        throw 'ProgramData path is not available.'
+    }
+
+    $candidate = Join-Path -Path $ProgramDataPath -ChildPath 'JKI\VIPM\Settings.ini'
+    if (-not (Test-Path -Path $candidate)) {
+        throw "VIPM Settings.ini not found at '$candidate'."
+    }
+
+    return (Resolve-Path -Path $candidate).Path
+}
+
+function Convert-VipmPathToWindows {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $Path
+    }
+
+    if ($Path -match '^[A-Za-z]:\\') {
+        return $Path
+    }
+
+    if ($Path -match '^/([A-Za-z])/(.*)$') {
+        $drive = $matches[1].ToUpperInvariant()
+        $rest = $matches[2] -replace '/', '\'
+        return ('{0}:\{1}' -f $drive, $rest)
+    }
+
+    return ($Path -replace '/', '\')
+}
+
+function Get-IndexedIniValues {
+    [CmdletBinding()]
+    param(
+        [string[]]$Lines,
+        [string]$KeyPrefix
+    )
+
+    $map = @{}
+    $pattern = '^\s*{0}\s+(\d+)="(.*)"\s*$' -f [regex]::Escape($KeyPrefix)
+    foreach ($line in $Lines) {
+        $match = [regex]::Match($line, $pattern)
+        if ($match.Success) {
+            $index = [int]$match.Groups[1].Value
+            $value = $match.Groups[2].Value
+            $map[$index] = $value
+        }
+    }
+
+    return $map
+}
+
+function Get-VipmPortsFromSettingsLines {
+    [CmdletBinding()]
+    param(
+        [string[]]$Lines
+    )
+
+    $line = $Lines | Where-Object { $_ -match '^\s*Ports="<size\(s\)=\d+>.*"\s*$' } | Select-Object -First 1
+    if (-not $line) {
+        throw 'Ports entry not found in VIPM Settings.ini.'
+    }
+
+    $match = [regex]::Match($line, '^\s*Ports="<size\(s\)=(\d+)>\s*(.*)"\s*$')
+    if (-not $match.Success) {
+        throw "Unable to parse VIPM Ports entry: $line"
+    }
+
+    $declaredSize = [int]$match.Groups[1].Value
+    $portsRaw = $match.Groups[2].Value.Trim()
+    $ports = @()
+    if (-not [string]::IsNullOrWhiteSpace($portsRaw)) {
+        $ports = $portsRaw -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    }
+
+    if ($declaredSize -ne $ports.Count) {
+        throw "VIPM Ports size mismatch: declared $declaredSize, actual $($ports.Count)."
+    }
+
+    return [pscustomobject]@{
+        DeclaredSize = $declaredSize
+        Ports        = @($ports)
+        Line         = $line
+    }
+}
+
+function Get-LabVIEWYearFromVipmVersion {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Version
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        return $null
+    }
+
+    $match = [regex]::Match($Version, '^(\d{1,4})')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    $major = [int]$match.Groups[1].Value
+    if ($major -ge 2000) {
+        return $major
+    }
+
+    if ($major -ge 0 -and $major -lt 100) {
+        return (2000 + $major)
+    }
+
+    return $null
+}
+
+function Resolve-VipmTargetBitness {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Version,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Location
+    )
+
+    if ($Version -match '\(64-bit\)') { return '64' }
+    if ($Version -match '\(32-bit\)') { return '32' }
+    if ($Location -match 'Program Files \(x86\)') { return '32' }
+    if ($Location -match 'Program Files\\') { return '64' }
+    if ($Location -match '/Program Files \(x86\)/') { return '32' }
+    if ($Location -match '/Program Files/') { return '64' }
+    return 'unknown'
+}
+
+function Get-LabVIEWServerPortFromIni {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LabVIEWIniPath
+    )
+
+    if (-not (Test-Path -Path $LabVIEWIniPath)) {
+        return $null
+    }
+
+    $line = Select-String -Path $LabVIEWIniPath -Pattern '^\s*server\.tcp\.port\s*=\s*(\d+)\s*$' -CaseSensitive:$false | Select-Object -First 1
+    if (-not $line) {
+        return $null
+    }
+
+    $match = [regex]::Match($line.Line, '^\s*server\.tcp\.port\s*=\s*(\d+)\s*$', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return [int]$match.Groups[1].Value
+}
+
+function Get-VipmTargetsFromSettings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SettingsPath
+    )
+
+    $resolvedSettingsPath = (Resolve-Path -Path $SettingsPath -ErrorAction Stop).Path
+    $lines = Get-Content -Path $resolvedSettingsPath
+
+    $versions = Get-IndexedIniValues -Lines $lines -KeyPrefix 'Versions'
+    $locations = Get-IndexedIniValues -Lines $lines -KeyPrefix 'Locations'
+    $disabledMap = Get-IndexedIniValues -Lines $lines -KeyPrefix 'Disabled'
+    $portsInfo = Get-VipmPortsFromSettingsLines -Lines $lines
+
+    $allIndexes = @()
+    $allIndexes += $versions.Keys
+    $allIndexes += $locations.Keys
+    $ports = @($portsInfo.Ports)
+    if ($ports.Count -gt 0) {
+        $allIndexes += (0..($ports.Count - 1))
+    }
+    $allIndexes = $allIndexes | Sort-Object -Unique
+
+    $targets = @()
+    foreach ($index in $allIndexes) {
+        $version = if ($versions.ContainsKey($index)) { $versions[$index] } else { $null }
+        $locationRaw = if ($locations.ContainsKey($index)) { $locations[$index] } else { $null }
+        $location = Convert-VipmPathToWindows -Path $locationRaw
+        $vipmPort = $null
+        if ($index -lt $ports.Count) {
+            $portValue = $ports[$index]
+            if ($portValue -match '^\d+$') {
+                $vipmPort = [int]$portValue
+            }
+        }
+
+        $labviewExePath = if ([string]::IsNullOrWhiteSpace($location)) { $null } else { $location }
+        $labviewIniPath = if ([string]::IsNullOrWhiteSpace($labviewExePath)) { $null } else { Join-Path -Path (Split-Path -Path $labviewExePath -Parent) -ChildPath 'LabVIEW.ini' }
+        $disabledRaw = if ($disabledMap.ContainsKey($index)) { $disabledMap[$index] } else { 'FALSE' }
+        $isDisabled = $disabledRaw.Trim().ToUpperInvariant() -eq 'TRUE'
+
+        $targets += [pscustomobject]@{
+            Index          = $index
+            Version        = $version
+            Year           = Get-LabVIEWYearFromVipmVersion -Version $version
+            Bitness        = Resolve-VipmTargetBitness -Version $version -Location $location
+            Location       = $location
+            LabVIEWExePath = $labviewExePath
+            LabVIEWIniPath = $labviewIniPath
+            VipmPort       = $vipmPort
+            Disabled       = $isDisabled
+        }
+    }
+
+    return $targets
+}
+
+function Test-VipmTargetPortAlignment {
+    [CmdletBinding()]
+    param(
+        [string]$SettingsPath,
+
+        [ValidateRange(2000, 2100)]
+        [int]$LabVIEWVersion,
+
+        [ValidateSet('32', '64', 'both')]
+        [string]$Bitness = 'both',
+
+        [switch]$IncludeDisabled
+    )
+
+    $resolvedSettingsPath = if ([string]::IsNullOrWhiteSpace($SettingsPath)) {
+        Get-VipmSettingsPath
+    } else {
+        (Resolve-Path -Path $SettingsPath -ErrorAction Stop).Path
+    }
+
+    $targets = Get-VipmTargetsFromSettings -SettingsPath $resolvedSettingsPath
+
+    if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
+        $targets = $targets | Where-Object { $_.Year -eq $LabVIEWVersion }
+    }
+
+    if ($Bitness -ne 'both') {
+        $targets = $targets | Where-Object { $_.Bitness -eq $Bitness }
+    }
+
+    if (-not $IncludeDisabled.IsPresent) {
+        $targets = $targets | Where-Object { -not $_.Disabled }
+    }
+
+    $warnings = @()
+    $mismatches = @()
+
+    foreach ($target in $targets) {
+        if ([string]::IsNullOrWhiteSpace($target.LabVIEWIniPath)) {
+            $warnings += [pscustomobject]@{
+                reason = 'missing_labview_ini_path'
+                index = $target.Index
+                version = $target.Version
+                bitness = $target.Bitness
+            }
+            continue
+        }
+
+        if (-not (Test-Path -Path $target.LabVIEWIniPath)) {
+            $warnings += [pscustomobject]@{
+                reason = 'labview_ini_not_found'
+                index = $target.Index
+                version = $target.Version
+                bitness = $target.Bitness
+                labview_ini_path = $target.LabVIEWIniPath
+            }
+            continue
+        }
+
+        $labviewPort = Get-LabVIEWServerPortFromIni -LabVIEWIniPath $target.LabVIEWIniPath
+        if ($null -eq $labviewPort) {
+            $mismatches += [pscustomobject]@{
+                reason = 'labview_ini_missing_server_port'
+                index = $target.Index
+                version = $target.Version
+                bitness = $target.Bitness
+                vipm_port = $target.VipmPort
+                labview_port = $null
+                labview_ini_path = $target.LabVIEWIniPath
+            }
+            continue
+        }
+
+        if ($null -eq $target.VipmPort) {
+            $mismatches += [pscustomobject]@{
+                reason = 'vipm_missing_port'
+                index = $target.Index
+                version = $target.Version
+                bitness = $target.Bitness
+                vipm_port = $null
+                labview_port = $labviewPort
+                labview_ini_path = $target.LabVIEWIniPath
+            }
+            continue
+        }
+
+        if ($target.VipmPort -ne $labviewPort) {
+            $mismatches += [pscustomobject]@{
+                reason = 'port_mismatch'
+                index = $target.Index
+                version = $target.Version
+                bitness = $target.Bitness
+                vipm_port = $target.VipmPort
+                labview_port = $labviewPort
+                labview_ini_path = $target.LabVIEWIniPath
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        checked_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+        settings_path = $resolvedSettingsPath
+        evaluated_target_count = @($targets).Count
+        mismatch_count = @($mismatches).Count
+        warning_count = @($warnings).Count
+        passed = (@($mismatches).Count -eq 0)
+        mismatches = @($mismatches)
+        warnings = @($warnings)
+    }
+}
+
+function Repair-VipmTargetPortAlignment {
+    [CmdletBinding()]
+    param(
+        [string]$SettingsPath,
+
+        [ValidateRange(2000, 2100)]
+        [int]$LabVIEWVersion,
+
+        [ValidateSet('32', '64', 'both')]
+        [string]$Bitness = 'both',
+
+        [switch]$IncludeDisabled
+    )
+
+    $resolvedSettingsPath = if ([string]::IsNullOrWhiteSpace($SettingsPath)) {
+        Get-VipmSettingsPath
+    } else {
+        (Resolve-Path -Path $SettingsPath -ErrorAction Stop).Path
+    }
+
+    $before = Test-VipmTargetPortAlignment -SettingsPath $resolvedSettingsPath -Bitness $Bitness -IncludeDisabled:$IncludeDisabled
+    if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
+        $before = Test-VipmTargetPortAlignment -SettingsPath $resolvedSettingsPath -LabVIEWVersion $LabVIEWVersion -Bitness $Bitness -IncludeDisabled:$IncludeDisabled
+    }
+
+    if ($before.mismatch_count -eq 0) {
+        return [pscustomobject]@{
+            changed = $false
+            backup_path = $null
+            before = $before
+            after = $before
+        }
+    }
+
+    $lines = Get-Content -Path $resolvedSettingsPath
+    $portsInfo = Get-VipmPortsFromSettingsLines -Lines $lines
+    $ports = @($portsInfo.Ports)
+
+    $changedIndexes = @()
+    foreach ($item in $before.mismatches) {
+        if ($item.reason -ne 'port_mismatch') {
+            continue
+        }
+        $idx = [int]$item.index
+        if ($idx -lt 0 -or $idx -ge $ports.Count) {
+            continue
+        }
+        $ports[$idx] = [string]$item.labview_port
+        $changedIndexes += $idx
+    }
+
+    if (@($changedIndexes).Count -eq 0) {
+        return [pscustomobject]@{
+            changed = $false
+            backup_path = $null
+            before = $before
+            after = $before
+        }
+    }
+
+    $backupPath = '{0}.bak-{1}' -f $resolvedSettingsPath, (Get-Date -Format 'yyyyMMdd-HHmmss')
+    Copy-Item -Path $resolvedSettingsPath -Destination $backupPath -Force
+
+    $newPortsLine = 'Ports="<size(s)={0}> {1}"' -f $ports.Count, ($ports -join ' ')
+    $portsLinePattern = '^\s*Ports="<size\(s\)=\d+>.*"\s*$'
+    $updatedLines = @()
+    $updated = $false
+    foreach ($line in $lines) {
+        if (-not $updated -and $line -match $portsLinePattern) {
+            $updatedLines += $newPortsLine
+            $updated = $true
+        } else {
+            $updatedLines += $line
+        }
+    }
+
+    if (-not $updated) {
+        throw 'Failed to update Ports entry in VIPM Settings.ini.'
+    }
+
+    Set-Content -Path $resolvedSettingsPath -Value $updatedLines -Encoding ascii
+
+    $afterArgs = @{
+        SettingsPath = $resolvedSettingsPath
+        Bitness = $Bitness
+        IncludeDisabled = $IncludeDisabled
+    }
+    if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
+        $afterArgs.LabVIEWVersion = $LabVIEWVersion
+    }
+    $after = Test-VipmTargetPortAlignment @afterArgs
+
+    return [pscustomobject]@{
+        changed = $true
+        backup_path = $backupPath
+        changed_indexes = @($changedIndexes | Sort-Object -Unique)
+        before = $before
+        after = $after
+    }
+}
+
+function Assert-VipmTargetPortAlignment {
+    [CmdletBinding()]
+    param(
+        [string]$SettingsPath,
+
+        [ValidateRange(2000, 2100)]
+        [int]$LabVIEWVersion,
+
+        [ValidateSet('32', '64', 'both')]
+        [string]$Bitness = 'both',
+
+        [switch]$IncludeDisabled
+    )
+
+    $args = @{
+        SettingsPath = $SettingsPath
+        Bitness = $Bitness
+        IncludeDisabled = $IncludeDisabled
+    }
+    if ($PSBoundParameters.ContainsKey('LabVIEWVersion')) {
+        $args.LabVIEWVersion = $LabVIEWVersion
+    }
+
+    $result = Test-VipmTargetPortAlignment @args
+    if (-not $result.passed) {
+        $payload = $result | ConvertTo-Json -Depth 8
+        throw "VIPM target port alignment check failed: $payload"
+    }
+
+    return $result
+}


### PR DESCRIPTION
## Summary
- add per-VIPB lock broker to serialize VIP builds by VIPB path
- wire lock acquisition/release into build-vip runtime
- expose lock timeout/stale knobs in composite action
- add behavioral + contract tests for lock and action wiring
- include new lock tests in standard Pester runner

## Defaults
- vipb_build_lock_timeout_seconds: 180
- vipb_build_lock_stale_seconds: 300

## Validation
- Invoke-Pester -Path 'Test/VipbBuildLock.Tests.ps1','Test/BuildVipLockContract.Tests.ps1' -CI