### PR TITLE
ci: stabilize upstream develop promotion (runner-cli in-place, vi-analyzer/vipc fixes)

### DIFF
--- a/.github/actions/missing-in-project/action.yml
+++ b/.github/actions/missing-in-project/action.yml
@@ -163,36 +163,36 @@ runs:
           }
         }
         $runnerCliProject = Join-Path $repoRoot 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+        $runnerCliInvoker = Join-Path $repoRoot 'Tooling/Invoke-RunnerCli.ps1'
         $useRunnerCliBinary = (-not [string]::IsNullOrWhiteSpace($runnerCliPath)) -and (Test-Path $runnerCliPath)
-        $canUseRunnerCli = $useRunnerCliBinary -or ((Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject))
+        $canUseRunnerCliInPlace = (Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject) -and (Test-Path $runnerCliInvoker)
+        $canUseRunnerCli = $canUseRunnerCliInPlace -or $useRunnerCliBinary
         if (-not $canUseRunnerCli -and $requireRunnerCli) {
-          throw "runner-cli is required but unavailable. Set LVIE_RUNNER_CLI_PATH or enable dotnet build for Tooling/runner-cli."
+          throw "runner-cli is required but unavailable. Ensure Tooling/Invoke-RunnerCli.ps1 + runner-cli project are present, or set LVIE_RUNNER_CLI_PATH."
         }
         if ($canUseRunnerCli) {
-          if ($useRunnerCliBinary -and -not $IsWindows) {
-            chmod +x $runnerCliPath
-          }
-          Write-Host "Using runner-cli missing-in-project (incremental migration)."
-          $args = @(
+          Write-Host "Using runner-cli missing-in-project."
+          $runnerCliArgs = @(
             'missing-in-project',
             '--repo-root', $repoRoot,
             '--arch', '${{ inputs.arch }}',
             '--project-file', $projectFile
           )
           if (-not [string]::IsNullOrWhiteSpace($lvInput)) {
-            $args += '--labview'
-            $args += $lvInput
+            $runnerCliArgs += '--labview'
+            $runnerCliArgs += $lvInput
           }
-          if ($useRunnerCliBinary) {
-            & $runnerCliPath @args
+          if ($canUseRunnerCliInPlace) {
+            & pwsh -NoProfile -File $runnerCliInvoker -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           } else {
-            $dotnetArgs = @(
-              'run',
-              '--project', $runnerCliProject,
-              '--configuration', 'Release',
-              '--'
-            ) + $args
-            & dotnet @dotnetArgs
+            if ($useRunnerCliBinary -and -not $IsWindows) {
+              chmod +x $runnerCliPath
+            }
+            if ($runnerCliPath -like '*.dll') {
+              & dotnet $runnerCliPath @runnerCliArgs
+            } else {
+              & $runnerCliPath @runnerCliArgs
+            }
           }
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0 -and $exitCode -ne $null) {

--- a/.github/actions/pylavi-validate/action.yml
+++ b/.github/actions/pylavi-validate/action.yml
@@ -126,15 +126,14 @@ runs:
           }
         }
         $runnerCliProject = Join-Path $env:GITHUB_WORKSPACE 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+        $runnerCliInvoker = Join-Path $env:GITHUB_WORKSPACE 'Tooling/Invoke-RunnerCli.ps1'
         $useRunnerCliBinary = (-not [string]::IsNullOrWhiteSpace($runnerCliPath)) -and (Test-Path $runnerCliPath)
-        $canUseRunnerCli = $useRunnerCliBinary -or ((Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject))
+        $canUseRunnerCliInPlace = (Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject) -and (Test-Path $runnerCliInvoker)
+        $canUseRunnerCli = $canUseRunnerCliInPlace -or $useRunnerCliBinary
         if (-not $canUseRunnerCli -and $needsRunnerCli) {
-          throw "runner-cli is required but unavailable. Set LVIE_RUNNER_CLI_PATH or enable dotnet build for Tooling/runner-cli."
+          throw "runner-cli is required but unavailable. Ensure Tooling/Invoke-RunnerCli.ps1 + runner-cli project are present, or set LVIE_RUNNER_CLI_PATH."
         }
         if ($canUseRunnerCli) {
-          if ($useRunnerCliBinary -and -not $IsWindows) {
-            chmod +x $runnerCliPath
-          }
           Write-Host "Using runner-cli pylavi scan (incremental migration)."
           $scanArgs = @(
             'pylavi', 'scan',
@@ -155,16 +154,17 @@ runs:
           if ('${{ inputs.report_only }}' -eq 'true') {
             $scanArgs += '--report-only'
           }
-          if ($useRunnerCliBinary) {
-            & $runnerCliPath @scanArgs
+          if ($canUseRunnerCliInPlace) {
+            & pwsh -NoProfile -File $runnerCliInvoker -RunnerCliProject $runnerCliProject -- @scanArgs
           } else {
-            $dotnetArgs = @(
-              'run',
-              '--project', $runnerCliProject,
-              '--configuration', 'Release',
-              '--'
-            ) + $scanArgs
-            & dotnet @dotnetArgs
+            if ($useRunnerCliBinary -and -not $IsWindows) {
+              chmod +x $runnerCliPath
+            }
+            if ($runnerCliPath -like '*.dll') {
+              & dotnet $runnerCliPath @scanArgs
+            } else {
+              & $runnerCliPath @scanArgs
+            }
           }
           $scanExit = $LASTEXITCODE
 
@@ -186,16 +186,14 @@ runs:
             if ($failOnDelta) {
               $summaryArgs += '--fail-on-delta'
             }
-            if ($useRunnerCliBinary) {
-              & $runnerCliPath @summaryArgs | Out-Host
+            if ($canUseRunnerCliInPlace) {
+              & pwsh -NoProfile -File $runnerCliInvoker -RunnerCliProject $runnerCliProject -- @summaryArgs | Out-Host
             } else {
-              $dotnetSummaryArgs = @(
-                'run',
-                '--project', $runnerCliProject,
-                '--configuration', 'Release',
-                '--'
-              ) + $summaryArgs
-              & dotnet @dotnetSummaryArgs | Out-Host
+              if ($runnerCliPath -like '*.dll') {
+                & dotnet $runnerCliPath @summaryArgs | Out-Host
+              } else {
+                & $runnerCliPath @summaryArgs | Out-Host
+              }
             }
           }
 

--- a/.github/actions/revert-development-mode/RevertDevelopmentMode.ps1
+++ b/.github/actions/revert-development-mode/RevertDevelopmentMode.ps1
@@ -361,7 +361,7 @@ function Invoke-RestoreLabviewSource {
         '--connect-timeout-ms', [string]$ConnectTimeoutMs,
         '--process-timeout-ms', [string]$ProcessTimeoutMs
     )
-    & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+    & pwsh -NoProfile -File (Join-Path $resolvedRepoRoot 'Tooling\Invoke-RunnerCli.ps1') -RunnerCliProject $runnerCliProject -- @runnerCliArgs
 
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
         throw "runner-cli dev-mode restore-source failed for $Bitness-bit with exit code $LASTEXITCODE."
@@ -379,6 +379,4 @@ try {
     Write-Error "An unexpected error occurred during script execution: $($_.Exception.Message)"
     exit 1
 }
-
-
 

--- a/.github/actions/set-development-mode/Set_Development_Mode.ps1
+++ b/.github/actions/set-development-mode/Set_Development_Mode.ps1
@@ -336,7 +336,7 @@ function Invoke-PrepareLabviewSource {
         '--connect-timeout-ms', [string]$ConnectTimeoutMs,
         '--process-timeout-ms', [string]$ProcessTimeoutMs
     )
-    & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+    & pwsh -NoProfile -File (Join-Path $resolvedRepoRoot 'Tooling\Invoke-RunnerCli.ps1') -RunnerCliProject $runnerCliProject -- @runnerCliArgs
 
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
         throw "runner-cli dev-mode prepare-source failed for $Bitness-bit with exit code $LASTEXITCODE."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,12 +561,12 @@ jobs:
           $versionOut = Join-Path $env:RUNNER_TEMP 'core-windows-version-gate.json'
           $pylaviOut = Join-Path $env:RUNNER_TEMP 'core-windows-pylavi-summarize.json'
           $evidenceOut = Join-Path $env:RUNNER_TEMP 'core-conformance-windows-evidence.json'
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- version-gate --repo-root $env:GITHUB_WORKSPACE --json | Out-File -FilePath $versionOut -Encoding utf8
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs @('version-gate','--repo-root',$env:GITHUB_WORKSPACE,'--json') | Out-File -FilePath $versionOut -Encoding utf8
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli version-gate failed with exit code $LASTEXITCODE"
           }
           $sample = Join-Path $env:GITHUB_WORKSPACE 'Tooling/pylavi/fixtures/pylavi-offenders.sample.json'
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- pylavi summarize --path $sample --json | Out-File -FilePath $pylaviOut -Encoding utf8
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs @('pylavi','summarize','--path',$sample,'--json') | Out-File -FilePath $pylaviOut -Encoding utf8
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli pylavi summarize failed with exit code $LASTEXITCODE"
           }
@@ -837,7 +837,7 @@ jobs:
             '--output-path', $auditPath,
             '--fail-on-mismatch', 'false'
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -885,7 +885,7 @@ jobs:
             '--supported-bitness', '64',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -915,7 +915,7 @@ jobs:
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
             '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-post-64.json"
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -1000,7 +1000,7 @@ jobs:
             '--supported-bitness', '64',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -1085,7 +1085,7 @@ jobs:
             '--output-path', $auditPath,
             '--fail-on-mismatch', 'false'
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -1133,7 +1133,7 @@ jobs:
             '--supported-bitness', '32',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -1163,7 +1163,7 @@ jobs:
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
             '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-post-32.json"
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -1248,7 +1248,7 @@ jobs:
             '--supported-bitness', '32',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -1466,7 +1466,7 @@ jobs:
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
             '--output-path', $precheckOutputPath
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
       - name: Test Source Using LV ${{ matrix.bitness }}-bit
         id: source_test
         shell: pwsh
@@ -1713,7 +1713,7 @@ jobs:
             $runnerCliArgs += '--verbose-gcli'
           }
           $lunitStartUtc = (Get-Date).ToUniversalTime()
-          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs *>&1
           $runnerCliExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
           $buildServerShutdownAfterExitCode = Invoke-DotnetBuildServerShutdown -Phase 'post-lunit'
           if ($output) {
@@ -2028,7 +2028,7 @@ jobs:
             '--build', '${{ needs.version.outputs.BUILD }}',
             '--commit', '${{ github.sha }}'
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           $runnerCliExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
           Write-Host ("runner-cli ppl build exit code: {0}" -f $runnerCliExitCode)
           exit $runnerCliExitCode
@@ -2141,7 +2141,7 @@ jobs:
             '--build', '${{ needs.version.outputs.BUILD }}',
             '--commit', '${{ github.sha }}'
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           $runnerCliExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
           Write-Host ("runner-cli ppl build exit code: {0}" -f $runnerCliExitCode)
           exit $runnerCliExitCode
@@ -2383,7 +2383,7 @@ jobs:
             '--display-information-json-path', $displayInformationJsonPath,
             '--vipm-timeout-seconds', $env:LVIE_VIPM_TIMEOUT_SECONDS
           )
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs $runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -2605,12 +2605,12 @@ jobs:
           }
 
           $contextPath = Join-Path $env:RUNNER_TEMP 'parity-context-linux-container.json'
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity context --repo-root $env:GITHUB_WORKSPACE --output $contextPath
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs @('parity','context','--repo-root',$env:GITHUB_WORKSPACE,'--output',$contextPath)
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity context failed with exit code $LASTEXITCODE."
           }
 
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity run --mode linux-container --context $contextPath --build-spec
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs @('parity','run','--mode','linux-container','--context',$contextPath,'--build-spec')
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity run failed with exit code $LASTEXITCODE."
           }
@@ -2751,12 +2751,12 @@ jobs:
           }
 
           $contextPath = Join-Path $env:RUNNER_TEMP 'parity-context-windows-container.json'
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity context --repo-root $env:GITHUB_WORKSPACE --output $contextPath
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs @('parity','context','--repo-root',$env:GITHUB_WORKSPACE,'--output',$contextPath)
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity context failed with exit code $LASTEXITCODE."
           }
 
-          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity run --mode windows-container --context $contextPath --build-spec
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -RunnerCliArgs @('parity','run','--mode','windows-container','--context',$contextPath,'--build-spec')
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity run failed with exit code $LASTEXITCODE."
           }
@@ -3564,3 +3564,4 @@ jobs:
           }
 
           Write-Host 'CI required context passed.'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,21 +552,21 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $cli = Join-Path $env:RUNNER_TEMP 'runner-cli/runner-cli.exe'
-          if (-not (Test-Path $cli)) {
-            throw "runner-cli artifact missing at $cli"
+          $runnerCliProject = Join-Path $env:GITHUB_WORKSPACE 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
+          if (-not (Test-Path -Path $runnerCliProject -PathType Leaf)) {
+            throw "runner-cli project not found at $runnerCliProject"
           }
           $runUrl = "{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID
           $evidence = "core-windows:${runUrl}:attempt-$($env:GITHUB_RUN_ATTEMPT)"
           $versionOut = Join-Path $env:RUNNER_TEMP 'core-windows-version-gate.json'
           $pylaviOut = Join-Path $env:RUNNER_TEMP 'core-windows-pylavi-summarize.json'
           $evidenceOut = Join-Path $env:RUNNER_TEMP 'core-conformance-windows-evidence.json'
-          & $cli version-gate --repo-root $env:GITHUB_WORKSPACE --json | Out-File -FilePath $versionOut -Encoding utf8
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- version-gate --repo-root $env:GITHUB_WORKSPACE --json | Out-File -FilePath $versionOut -Encoding utf8
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli version-gate failed with exit code $LASTEXITCODE"
           }
           $sample = Join-Path $env:GITHUB_WORKSPACE 'Tooling/pylavi/fixtures/pylavi-offenders.sample.json'
-          & $cli pylavi summarize --path $sample --json | Out-File -FilePath $pylaviOut -Encoding utf8
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- pylavi summarize --path $sample --json | Out-File -FilePath $pylaviOut -Encoding utf8
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli pylavi summarize failed with exit code $LASTEXITCODE"
           }
@@ -754,24 +754,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Download runner-cli artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.runner-cli-build-win.outputs.artifact_name }}
-          path: ${{ runner.temp }}/runner-cli
-      - name: Export runner-cli path
-        shell: pwsh
-        run: |
-          $cliPath = Join-Path $env:RUNNER_TEMP 'runner-cli' 'runner-cli.exe'
-          if (Test-Path $cliPath) {
-            "LVIE_RUNNER_CLI_PATH=$cliPath" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding ascii
-            Write-Host ("Using runner-cli at {0}" -f $cliPath)
-          } else {
-            Write-Warning ("runner-cli artifact missing at {0}" -f $cliPath)
-            if ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1') {
-              throw "LVIE_REQUIRE_RUNNER_CLI=1 but runner-cli was not found."
-            }
-          }
       - name: Run vi_validate (strict, report-only)
         uses: ./.github/actions/pylavi-validate
         with:
@@ -855,7 +837,7 @@ jobs:
             '--output-path', $auditPath,
             '--fail-on-mismatch', 'false'
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -903,7 +885,7 @@ jobs:
             '--supported-bitness', '64',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -933,7 +915,7 @@ jobs:
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
             '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-post-64.json"
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -1018,7 +1000,7 @@ jobs:
             '--supported-bitness', '64',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -1103,7 +1085,7 @@ jobs:
             '--output-path', $auditPath,
             '--fail-on-mismatch', 'false'
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -1151,7 +1133,7 @@ jobs:
             '--supported-bitness', '32',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -1181,7 +1163,7 @@ jobs:
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
             '--output-path', "$env:REPO_ROOT\\builds\\status\\vipc-audit-post-32.json"
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -1266,7 +1248,7 @@ jobs:
             '--supported-bitness', '32',
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc'
           )
-          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
           $exitCode = $LASTEXITCODE
 
           if ($output) {
@@ -1484,7 +1466,7 @@ jobs:
             '--vipc-path', '.github/actions/apply-vipc/runner_dependencies.vipc',
             '--output-path', $precheckOutputPath
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
       - name: Test Source Using LV ${{ matrix.bitness }}-bit
         id: source_test
         shell: pwsh
@@ -1731,7 +1713,7 @@ jobs:
             $runnerCliArgs += '--verbose-gcli'
           }
           $lunitStartUtc = (Get-Date).ToUniversalTime()
-          $output = & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs *>&1
+          $output = & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs *>&1
           $runnerCliExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
           $buildServerShutdownAfterExitCode = Invoke-DotnetBuildServerShutdown -Phase 'post-lunit'
           if ($output) {
@@ -2046,7 +2028,7 @@ jobs:
             '--build', '${{ needs.version.outputs.BUILD }}',
             '--commit', '${{ github.sha }}'
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           $runnerCliExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
           Write-Host ("runner-cli ppl build exit code: {0}" -f $runnerCliExitCode)
           exit $runnerCliExitCode
@@ -2159,7 +2141,7 @@ jobs:
             '--build', '${{ needs.version.outputs.BUILD }}',
             '--commit', '${{ github.sha }}'
           )
-          & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           $runnerCliExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
           Write-Host ("runner-cli ppl build exit code: {0}" -f $runnerCliExitCode)
           exit $runnerCliExitCode
@@ -2372,26 +2354,12 @@ jobs:
       - name: Build VI Package (LV 64-bit)
         shell: pwsh
         run: |
-          $runnerCliPath = $env:LVIE_RUNNER_CLI_PATH
-          $ensureRunnerCliScript = @(
-            (Join-Path $env:REPO_ROOT 'Tooling/Ensure-RunnerCli.ps1'),
-            (Join-Path $env:GITHUB_WORKSPACE 'Tooling/Ensure-RunnerCli.ps1')
-          ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -Path $_ -PathType Leaf) } | Select-Object -First 1
-          if ($ensureRunnerCliScript) {
-            $ensureResult = & $ensureRunnerCliScript -RepoRoot $env:REPO_ROOT -RunnerCliPath $runnerCliPath -Require
-            if ($ensureResult -and -not [string]::IsNullOrWhiteSpace($ensureResult.Path)) {
-              $runnerCliPath = $ensureResult.Path
-            }
-          }
-          $usePrebuiltRunnerCli = -not [string]::IsNullOrWhiteSpace($runnerCliPath) -and (Test-Path -Path $runnerCliPath -PathType Leaf)
           $runnerCliProject = @(
             (Join-Path $env:REPO_ROOT 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'),
             (Join-Path $env:GITHUB_WORKSPACE 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj')
           ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -Path $_ -PathType Leaf) } | Select-Object -First 1
-          if ($usePrebuiltRunnerCli) {
-            Write-Host ("Using prebuilt runner-cli at {0}" -f $runnerCliPath)
-          } elseif (-not $runnerCliProject) {
-            throw "runner-cli unavailable: no usable LVIE_RUNNER_CLI_PATH and no runner-cli project found under REPO_ROOT/GITHUB_WORKSPACE."
+          if (-not $runnerCliProject) {
+            throw "runner-cli project not found under REPO_ROOT/GITHUB_WORKSPACE."
           }
 
           $displayInformationJsonPath = '${{ steps.display-info.outputs.display_information_json_path }}'
@@ -2415,11 +2383,7 @@ jobs:
             '--display-information-json-path', $displayInformationJsonPath,
             '--vipm-timeout-seconds', $env:LVIE_VIPM_TIMEOUT_SECONDS
           )
-          if ($usePrebuiltRunnerCli) {
-            & $runnerCliPath @runnerCliArgs
-          } else {
-            & dotnet run --project $runnerCliProject --configuration Release -- @runnerCliArgs
-          }
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- @runnerCliArgs
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -2641,12 +2605,12 @@ jobs:
           }
 
           $contextPath = Join-Path $env:RUNNER_TEMP 'parity-context-linux-container.json'
-          & dotnet run --project $runnerCliProject --configuration Release -- parity context --repo-root $env:GITHUB_WORKSPACE --output $contextPath
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity context --repo-root $env:GITHUB_WORKSPACE --output $contextPath
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity context failed with exit code $LASTEXITCODE."
           }
 
-          & dotnet run --project $runnerCliProject --configuration Release -- parity run --mode linux-container --context $contextPath --build-spec
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity run --mode linux-container --context $contextPath --build-spec
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity run failed with exit code $LASTEXITCODE."
           }
@@ -2787,12 +2751,12 @@ jobs:
           }
 
           $contextPath = Join-Path $env:RUNNER_TEMP 'parity-context-windows-container.json'
-          & dotnet run --project $runnerCliProject --configuration Release -- parity context --repo-root $env:GITHUB_WORKSPACE --output $contextPath
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity context --repo-root $env:GITHUB_WORKSPACE --output $contextPath
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity context failed with exit code $LASTEXITCODE."
           }
 
-          & dotnet run --project $runnerCliProject --configuration Release -- parity run --mode windows-container --context $contextPath --build-spec
+          & pwsh -NoProfile -File ./Tooling/Invoke-RunnerCli.ps1 -RunnerCliProject $runnerCliProject -- parity run --mode windows-container --context $contextPath --build-spec
           if ($LASTEXITCODE -ne 0) {
             throw "runner-cli parity run failed with exit code $LASTEXITCODE."
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1452,9 +1452,9 @@ jobs:
       matrix:
         include:
           - bitness: '64'
-            runner_label: ${{ vars.LVIE_RUNNER_LABEL_64 || vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
+            runner_label: ${{ vars.LVIE_RUNNER_LABEL_64 || format('self-hosted-windows-lv{0}x64', needs.version-gate.outputs.year) }}
           - bitness: '32'
-            runner_label: ${{ vars.LVIE_RUNNER_LABEL_32 || vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
+            runner_label: ${{ vars.LVIE_RUNNER_LABEL_32 || format('self-hosted-windows-lv{0}x86', needs.version-gate.outputs.year) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Tooling/Invoke-RunnerCli.ps1
+++ b/Tooling/Invoke-RunnerCli.ps1
@@ -1,0 +1,47 @@
+#Requires -Version 7.0
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RunnerCliProject,
+
+    [string]$Configuration = 'Release',
+
+    [switch]$SkipBuild,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RunnerCliArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw 'dotnet is required to run runner-cli in-place.'
+}
+
+$projectPath = (Resolve-Path -Path $RunnerCliProject -ErrorAction Stop).Path
+$projectDir = Split-Path -Path $projectPath -Parent
+
+if (-not $SkipBuild.IsPresent) {
+    $buildArgs = @(
+        'build',
+        $projectPath,
+        '--configuration', $Configuration,
+        '-p:SelfContained=false',
+        '-p:UseAppHost=false'
+    )
+    & dotnet @buildArgs | Out-Host
+    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
+        throw ("runner-cli build failed with exit code {0}." -f $LASTEXITCODE)
+    }
+}
+
+$runnerCliDll = Join-Path $projectDir ("bin/{0}/net8.0/runner-cli.dll" -f $Configuration)
+if (-not (Test-Path -Path $runnerCliDll -PathType Leaf)) {
+    throw "runner-cli assembly was not found at $runnerCliDll"
+}
+
+& dotnet $runnerCliDll @RunnerCliArgs
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne $null) {
+    exit $exitCode
+}

--- a/Tooling/Invoke-RunnerCli.ps1
+++ b/Tooling/Invoke-RunnerCli.ps1
@@ -30,7 +30,7 @@ if (-not $SkipBuild.IsPresent) {
         '-p:UseAppHost=false'
     )
     & dotnet @buildArgs | Out-Host
-    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
+    if ($LASTEXITCODE -ne 0 -and $null -ne $LASTEXITCODE) {
         throw ("runner-cli build failed with exit code {0}." -f $LASTEXITCODE)
     }
 }
@@ -42,6 +42,7 @@ if (-not (Test-Path -Path $runnerCliDll -PathType Leaf)) {
 
 & dotnet $runnerCliDll @RunnerCliArgs
 $exitCode = $LASTEXITCODE
-if ($exitCode -ne $null) {
+if ($null -ne $exitCode) {
     exit $exitCode
 }
+

--- a/Tooling/Run-CI.ps1
+++ b/Tooling/Run-CI.ps1
@@ -1603,8 +1603,8 @@ function Invoke-RunnerCliCommand {
         throw "runner-cli was not found and project fallback is unavailable at $runnerCliProject"
     }
 
-    Write-Host ("{0}: dotnet run --project {1} -- {2}" -f $Label, (Format-RunnerCliArgument -Value $runnerCliProject), (($Arguments | ForEach-Object { Format-RunnerCliArgument -Value $_ }) -join ' '))
-    & dotnet run --project $runnerCliProject --configuration Release -- @Arguments
+    Write-Host ("{0}: runner-cli in-place ({1}) -- {2}" -f $Label, (Format-RunnerCliArgument -Value $runnerCliProject), (($Arguments | ForEach-Object { Format-RunnerCliArgument -Value $_ }) -join ' '))
+    & pwsh -NoProfile -File (Join-Path $RepoRoot 'Tooling\Invoke-RunnerCli.ps1') -RunnerCliProject $runnerCliProject -- @Arguments
 }
 
 function Initialize-RunnerContractIfNeeded {
@@ -2589,12 +2589,4 @@ finally {
     "{0},{1},{2},{3}" -f $runTimestamp, $runStatus, $runDuration, ($commandLine -replace ',', ' ') | Add-Content -Path $script:RunHistoryPath
     Pop-Location
 }
-
-
-
-
-
-
-
-
 

--- a/Tooling/Run-ViAnalyzer.ps1
+++ b/Tooling/Run-ViAnalyzer.ps1
@@ -30,7 +30,15 @@ param(
     [string]$ReportsRoot = 'builds/vi-analyzer',
 
     [Parameter(Mandatory = $false)]
-    [string]$StatusPath = 'builds/status/vi-analyzer-summary.json'
+    [string]$StatusPath = 'builds/status/vi-analyzer-summary.json',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 3)]
+    [int]$TaskMaxAttempts = 2,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(0, 30)]
+    [int]$TransientRetryDelaySeconds = 5
 )
 
 $ErrorActionPreference = 'Stop'
@@ -76,6 +84,51 @@ function Initialize-Directory {
     if (-not (Test-Path -Path $Path -PathType Container)) {
         New-Item -Path $Path -ItemType Directory -Force | Out-Null
     }
+}
+
+function Test-ViAnalyzerInstallation {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LabVIEWExecutablePath
+    )
+
+    $labviewRoot = Split-Path -Path $LabVIEWExecutablePath -Parent
+    $analyzerRoot = Join-Path $labviewRoot 'vi.lib\addons\analyzer'
+    $missingPaths = New-Object 'System.Collections.Generic.List[string]'
+    if (-not (Test-Path -Path $analyzerRoot -PathType Container)) {
+        $missingPaths.Add($analyzerRoot) | Out-Null
+    }
+
+    return [pscustomobject]@{
+        installed     = ($missingPaths.Count -eq 0)
+        analyzer_root = $analyzerRoot
+        missing_paths = $missingPaths.ToArray()
+    }
+}
+
+function Test-IsTransientLabVIEWCliConnectionFailure {
+    param(
+        [int]$ExitCode,
+        [string[]]$OutputLines
+    )
+
+    if ($ExitCode -eq 0) {
+        return $false
+    }
+
+    $text = if ($OutputLines -and $OutputLines.Count -gt 0) {
+        $OutputLines -join [Environment]::NewLine
+    } else {
+        ''
+    }
+
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $false
+    }
+
+    return $text -match 'Error code\s*:\s*-350000' `
+        -or $text -match 'failed to establish a connection with LabVIEW' `
+        -or $text -match 'The CLI for LabVIEW failed to establish a connection'
 }
 
 function Test-EnabledValue {
@@ -387,6 +440,49 @@ if ([string]::IsNullOrWhiteSpace($resolvedLabVIEWYear)) {
 }
 
 $labviewExecutablePath = Resolve-LabVIEWExecutablePath -VersionYear $resolvedLabVIEWYear -Bitness $SupportedBitness
+$viAnalyzerInstall = Test-ViAnalyzerInstallation -LabVIEWExecutablePath $labviewExecutablePath
+if (-not $viAnalyzerInstall.installed) {
+    $missingText = @($viAnalyzerInstall.missing_paths) -join '; '
+    throw ("VI Analyzer is not installed for LabVIEW {0} ({1}-bit). Missing expected path(s): {2}" -f $resolvedLabVIEWYear, $SupportedBitness, $missingText)
+}
+
+function Test-IsAllowlistedViAnalyzerFailureItem {
+    param(
+        [AllowNull()]
+        [psobject]$FailureItem
+    )
+
+    if ($null -eq $FailureItem) {
+        return $false
+    }
+
+    $section = [string]$FailureItem.section
+    $message = [string]$FailureItem.message
+    $filePath = [string]$FailureItem.file_path
+    if (-not $section.Equals('testing_errors', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+
+    if ($message -notmatch 'Error\s+1040\..*password protected') {
+        return $false
+    }
+
+    if ([string]::IsNullOrWhiteSpace($filePath)) {
+        return $false
+    }
+
+    $normalizedFilePath = $filePath -replace '/', '\'
+    if ($normalizedFilePath -match '(?i)\\vi\.lib\\LabVIEW Icon API\\lv_icon\\Support\\') {
+        return $true
+    }
+
+    if ($normalizedFilePath -match '(?i)\\resource\\plugins\\NIIconEditor\\') {
+        return $true
+    }
+
+    return $false
+}
+
 $portRemediationEnabled = Test-EnabledValue -Value $env:LVIE_REMEDIATE_LABVIEWCLI_PORT_CONTRACT
 if ($portRemediationEnabled) {
     Write-Warning 'LabVIEWCLI port contract remediation is enabled via LVIE_REMEDIATE_LABVIEWCLI_PORT_CONTRACT.'
@@ -406,6 +502,7 @@ if (-not $labviewCliCommand) {
 
 Write-Host ("Resolved LabVIEW: raw={0}, year={1}, bitness={2}" -f $resolvedLabVIEWVersionRaw, $resolvedLabVIEWYear, $SupportedBitness)
 Write-Host ("LabVIEW executable: {0}" -f $labviewExecutablePath)
+Write-Host ("VI Analyzer install root: {0}" -f $viAnalyzerInstall.analyzer_root)
 Write-Host ("Using LabVIEWCLI port {0} (source: {1})" -f $portResolution.PortNumber, $portResolution.Source)
 if ($portResolution.RemediationEnabled -and $portResolution.RemediationApplied) {
     Write-Warning ("LabVIEWCLI port contract remediation modified LabVIEW.ini at {0}" -f $portResolution.IniPath)
@@ -440,7 +537,7 @@ foreach ($task in $tasks) {
 
     Write-Host ""
     Write-Host ("=== VI Analyzer task: {0} ===" -f $taskId)
-    $start = Get-Date
+    $maxAttempts = [Math]::Max(1, [int]$TaskMaxAttempts)
     $cliArgs = @(
         '-OperationName', 'RunVIAnalyzer',
         '-LabVIEWPath', $labviewExecutablePath,
@@ -452,24 +549,64 @@ foreach ($task in $tasks) {
         '-Headless'
     )
 
-    $rawOutput = & $labviewCliCommand.Source @cliArgs 2>&1
-    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    $attempt = 0
+    $exitCode = 0
+    $durationMs = 0
     $outputLines = @()
-    foreach ($entry in @($rawOutput)) {
-        if ($null -ne $entry) {
-            $line = [string]$entry
-            $outputLines += $line
-            Write-Host $line
+    $attemptResults = New-Object 'System.Collections.Generic.List[object]'
+    while ($true) {
+        $attempt += 1
+        if ($attempt -gt 1) {
+            Write-Host ("Retrying VI Analyzer task '{0}' attempt {1}/{2}..." -f $taskId, $attempt, $maxAttempts)
         }
+
+        $start = Get-Date
+        $rawOutput = & $labviewCliCommand.Source @cliArgs 2>&1
+        $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+        $outputLines = @()
+        foreach ($entry in @($rawOutput)) {
+            if ($null -ne $entry) {
+                $line = [string]$entry
+                $outputLines += $line
+                Write-Host $line
+            }
+        }
+        $durationMs = [int][Math]::Round(((Get-Date) - $start).TotalMilliseconds)
+
+        $isTransientConnectionFailure = Test-IsTransientLabVIEWCliConnectionFailure `
+            -ExitCode $exitCode `
+            -OutputLines $outputLines
+        $attemptResults.Add([pscustomobject]@{
+                attempt                      = $attempt
+                exit_code                    = $exitCode
+                duration_ms                  = $durationMs
+                transient_connection_failure = $isTransientConnectionFailure
+            }) | Out-Null
+
+        if ($isTransientConnectionFailure -and $attempt -lt $maxAttempts) {
+            Write-Warning ("Transient LabVIEWCLI connection failure detected for task '{0}' on attempt {1}/{2}; retrying in {3}s." -f $taskId, $attempt, $maxAttempts, $TransientRetryDelaySeconds)
+            if ($TransientRetryDelaySeconds -gt 0) {
+                Start-Sleep -Seconds $TransientRetryDelaySeconds
+            }
+            continue
+        }
+
+        break
     }
-    $durationMs = [int][Math]::Round(((Get-Date) - $start).TotalMilliseconds)
 
     $cliCounts = Get-LabVIEWCliSummaryCount -Lines $outputLines
     $reportText = Get-ViAnalyzerReportText -ReportPath $reportPath
     $reportCounts = Get-ViAnalyzerReportCount -ReportText $reportText
     $counts = Join-ViAnalyzerCount -CliCounts $cliCounts -ReportCounts $reportCounts
     $failureItems = Get-ViAnalyzerFailureItemList -ReportText $reportText
-    $failureFilePaths = Get-OrderedUniqueFilePathList -Items $failureItems
+    $allowlistedFailureItems = @($failureItems | Where-Object { Test-IsAllowlistedViAnalyzerFailureItem -FailureItem $_ })
+    $nonAllowlistedFailureItems = @($failureItems | Where-Object { -not (Test-IsAllowlistedViAnalyzerFailureItem -FailureItem $_) })
+    $failureFilePaths = Get-OrderedUniqueFilePathList -Items $nonAllowlistedFailureItems
+    $allowlistedTestErrorCount = $allowlistedFailureItems.Count
+    $effectiveTestErrorCount = $null
+    if ($null -ne $counts.test_error) {
+        $effectiveTestErrorCount = [Math]::Max(0, ([int]$counts.test_error - $allowlistedTestErrorCount))
+    }
 
     $failureReasons = New-Object 'System.Collections.Generic.List[string]'
     if (-not (Test-Path -Path $reportPath -PathType Leaf)) {
@@ -498,18 +635,21 @@ foreach ($task in $tasks) {
     if ($null -ne $counts.test_unrunnable -and [int]$counts.test_unrunnable -gt 0) {
         $failureReasons.Add(("Test unrunnable count is {0}" -f $counts.test_unrunnable)) | Out-Null
     }
-    if ($null -ne $counts.test_error -and [int]$counts.test_error -gt 0) {
-        $failureReasons.Add(("Test error count is {0}" -f $counts.test_error)) | Out-Null
+    if ($null -ne $effectiveTestErrorCount -and [int]$effectiveTestErrorCount -gt 0) {
+        $failureReasons.Add(("Test error count is {0} (allowlisted={1})" -f $effectiveTestErrorCount, $allowlistedTestErrorCount)) | Out-Null
     }
 
     $taskSucceeded = $failureReasons.Count -eq 0
+    if ($allowlistedFailureItems.Count -gt 0) {
+        Write-Warning ("Allowlisted password-protected VI Analyzer testing errors for task '{0}': {1}" -f $taskId, $allowlistedFailureItems.Count)
+    }
     if (-not $taskSucceeded) {
         $overallSuccess = $false
-        if ($failureItems.Count -gt 0) {
+        if ($nonAllowlistedFailureItems.Count -gt 0) {
             Write-Host ("Failure details for task '{0}':" -f $taskId)
             foreach ($filePath in $failureFilePaths) {
                 Write-Host ("- File: {0}" -f $filePath)
-                foreach ($item in @($failureItems | Where-Object { $_.file_path -eq $filePath })) {
+                foreach ($item in @($nonAllowlistedFailureItems | Where-Object { $_.file_path -eq $filePath })) {
                     Write-Host ("  - [{0}] {1}: {2}" -f $item.section, $item.check_name, $item.message)
                 }
             }
@@ -524,10 +664,17 @@ foreach ($task in $tasks) {
             report_path     = $reportPath
             exit_code       = $exitCode
             duration_ms     = $durationMs
+            attempt_count   = $attempt
+            max_attempts    = $maxAttempts
+            retry_applied   = ($attempt -gt 1)
+            attempts        = $attemptResults.ToArray()
             succeeded       = $taskSucceeded
             counts          = [pscustomobject]$counts
-            failure_reasons = @($failureReasons)
-            failure_items   = @($failureItems)
+            effective_test_error_count = $effectiveTestErrorCount
+            allowlisted_test_error_count = $allowlistedTestErrorCount
+            failure_reasons = $failureReasons.ToArray()
+            failure_items   = @($nonAllowlistedFailureItems)
+            allowlisted_failure_items = @($allowlistedFailureItems)
             failure_file_paths = @($failureFilePaths)
         }) | Out-Null
 }
@@ -545,6 +692,10 @@ $status = [ordered]@{
         minor_revision  = [int]$labviewInfo.MinorRevision
         bitness         = $SupportedBitness
         executable_path = $labviewExecutablePath
+    }
+    vi_analyzer_installation = [ordered]@{
+        installed     = [bool]$viAnalyzerInstall.installed
+        analyzer_root = [string]$viAnalyzerInstall.analyzer_root
     }
     port             = [ordered]@{
         number        = [int]$portResolution.PortNumber

--- a/Tooling/Test-RunnerCliWave1WorkflowContract.ps1
+++ b/Tooling/Test-RunnerCliWave1WorkflowContract.ps1
@@ -137,6 +137,14 @@ if ($script:findings.Count -eq 0) {
         -Pattern 'Tooling/runner-cli/RunnerCli/RunnerCli\.csproj' `
         -Code 'missing-required-pattern' `
         -Message 'ci.yml must resolve runner-cli project path.'
+    Test-Pattern -FilePath $ciPath -Content $ciContent `
+        -Pattern 'Invoke-RunnerCli\.ps1' `
+        -Code 'missing-required-pattern' `
+        -Message 'ci.yml must route runner-cli commands through Tooling/Invoke-RunnerCli.ps1.'
+    Test-Pattern -FilePath $ciCompositePath -Content $ciCompositeContent `
+        -Pattern 'Invoke-RunnerCli\.ps1' `
+        -Code 'missing-required-pattern' `
+        -Message 'ci.yml must route runner-cli commands through Tooling/Invoke-RunnerCli.ps1.'
 
     Test-Pattern -FilePath $ciPath -Content $ciContent `
         -Pattern "'lunit', 'run'" `
@@ -225,6 +233,16 @@ if ($script:findings.Count -eq 0) {
         -Pattern 'runlabview-windows\.ps1' `
         -Code 'forbidden-legacy-call' `
         -Message 'ci.yml must not directly invoke runlabview-windows.ps1 in container PPL lanes after Wave 2 migration.' `
+        -MustNotExist
+    Test-Pattern -FilePath $ciPath -Content $ciContent `
+        -Pattern 'runner-cli\.exe' `
+        -Code 'forbidden-legacy-call' `
+        -Message 'ci.yml must not invoke runner-cli.exe directly; use Tooling/Invoke-RunnerCli.ps1 in-place execution.' `
+        -MustNotExist
+    Test-Pattern -FilePath $ciCompositePath -Content $ciCompositeContent `
+        -Pattern 'runner-cli\.exe' `
+        -Code 'forbidden-legacy-call' `
+        -Message 'ci.yml must not invoke runner-cli.exe directly; use Tooling/Invoke-RunnerCli.ps1 in-place execution.' `
         -MustNotExist
     $allowedExecutionPolicies = @('RemoteSigned', 'AllSigned', 'Restricted', 'Undefined', 'Default')
     Test-ExecutionPolicyAllowlist -FilePath $ciPath -Content $ciContent -Allowlist $allowedExecutionPolicies

--- a/Tooling/runner-cli/RunnerCli.Tests/RunnerCliCliTests.cs
+++ b/Tooling/runner-cli/RunnerCli.Tests/RunnerCliCliTests.cs
@@ -855,6 +855,20 @@ public class RunnerCliCliTests
     }
 
     [Fact]
+    public void Vipc_assert_dry_run_fail_on_mismatch_false_uses_boolean_switch_syntax()
+    {
+        var repoRoot = FindRepoRoot();
+        var outputPath = Path.Combine(repoRoot, "builds", "status", "vipc-audit-64.json");
+        var args = $"vipc assert --repo-root \"{repoRoot}\" --supported-bitness 64 --vipc-path \".github/actions/apply-vipc/runner_dependencies.vipc\" --output-path \"{outputPath}\" --fail-on-mismatch false --dry-run";
+        var (exitCode, stdout, stderr) = RunCli(repoRoot, args);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(string.IsNullOrWhiteSpace(stdout), $"stdout: {stdout}");
+        Assert.Contains("vipc assert command:", stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("-FailOnMismatch:$false", stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Vipc_apply_dry_run_emits_apply_vipc_command()
     {
         var repoRoot = FindRepoRoot();

--- a/Tooling/runner-cli/RunnerCli/VipcService.cs
+++ b/Tooling/runner-cli/RunnerCli/VipcService.cs
@@ -96,8 +96,7 @@ public static class VipcService
         AddValueArg(args, "-LabVIEWVersion", options.LabviewVersion);
         if (!options.FailOnMismatch)
         {
-            args.Add("-FailOnMismatch");
-            args.Add("false");
+            args.Add("-FailOnMismatch:$false");
         }
 
         return PowerShellScriptRunner.Run(

--- a/Tooling/tests/Invoke-RunnerCliContract.Tests.ps1
+++ b/Tooling/tests/Invoke-RunnerCliContract.Tests.ps1
@@ -1,0 +1,21 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Invoke-RunnerCli contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+        $script:invokerPath = Join-Path $script:repoRoot 'Tooling\Invoke-RunnerCli.ps1'
+    }
+
+    It 'exists' {
+        Test-Path -LiteralPath $script:invokerPath -PathType Leaf | Should -BeTrue
+    }
+
+    It 'enforces in-place non-apphost build flags' {
+        $content = Get-Content -LiteralPath $script:invokerPath -Raw
+        $content | Should -Match '-p:SelfContained=false'
+        $content | Should -Match '-p:UseAppHost=false'
+    }
+}

--- a/Tooling/tests/RunViAnalyzerReportParsing.Tests.ps1
+++ b/Tooling/tests/RunViAnalyzerReportParsing.Tests.ps1
@@ -39,6 +39,8 @@ Describe 'Run-ViAnalyzer report parsing contract' {
                 (Get-FunctionDefinitionText -Ast $ast -FunctionName 'Get-ViAnalyzerFailureItemList')
                 ''
                 (Get-FunctionDefinitionText -Ast $ast -FunctionName 'Get-OrderedUniqueFilePathList')
+                ''
+                (Get-FunctionDefinitionText -Ast $ast -FunctionName 'Test-IsAllowlistedViAnalyzerFailureItem')
             ) -Encoding utf8
 
         . $harnessPath
@@ -80,5 +82,25 @@ Describe 'Run-ViAnalyzer report parsing contract' {
             'C:\actions-runner\_work\Tooling\Unset Run Icon Editor from Source.vi',
             'C:\actions-runner\_work\Tooling\Mass Compile Runner.vi'
         )
+    }
+
+    It 'allowlists known password-protected testing errors under NI icon API/plugin paths' {
+        $item = [pscustomobject]@{
+            section   = 'testing_errors'
+            file_path = 'C:\actions-runner\_work\repo\resource\plugins\NIIconEditor\Support\IE_Resolve Symbolic Paths.vi'
+            message   = 'Error 1040.  VI is password protected.'
+        }
+
+        (Test-IsAllowlistedViAnalyzerFailureItem -FailureItem $item) | Should -BeTrue
+    }
+
+    It 'does not allowlist unrelated testing errors' {
+        $item = [pscustomobject]@{
+            section   = 'testing_errors'
+            file_path = 'C:\actions-runner\_work\repo\Tooling\Some Helper.vi'
+            message   = 'Error 7. File not found.'
+        }
+
+        (Test-IsAllowlistedViAnalyzerFailureItem -FailureItem $item) | Should -BeFalse
     }
 }

--- a/Tooling/tests/ViAnalyzerContract.Tests.ps1
+++ b/Tooling/tests/ViAnalyzerContract.Tests.ps1
@@ -121,10 +121,22 @@ Describe 'VI Analyzer contract' {
         (Test-Path -LiteralPath $script:runViAnalyzerPath -PathType Leaf) | Should -BeTrue
 
         $content = Get-Content -Raw -Path $script:runViAnalyzerPath
+        $content | Should -Match 'Test-ViAnalyzerInstallation'
+        $content | Should -Match 'vi\.lib\\addons\\analyzer'
         $content | Should -Match 'Resolve-LabVIEWCliPortFromContract'
         $content | Should -Match 'LVIE_REMEDIATE_LABVIEWCLI_PORT_CONTRACT'
         $content | Should -Match '-EnableRemediation:\$portRemediationEnabled'
         $content | Should -Match 'RunVIAnalyzer'
+        $content | Should -Match 'TaskMaxAttempts'
+        $content | Should -Match 'TransientRetryDelaySeconds'
+        $content | Should -Match 'Test-IsTransientLabVIEWCliConnectionFailure'
+        $content | Should -Match 'Test-IsAllowlistedViAnalyzerFailureItem'
+        $content | Should -Match 'password protected'
+        $content | Should -Match 'allowlisted_test_error_count'
+        $content | Should -Match 'effective_test_error_count'
+        $content | Should -Match 'Transient LabVIEWCLI connection failure detected'
+        $content | Should -Match 'attempt_count'
+        $content | Should -Match 'retry_applied'
         $content | Should -Match 'analyzed_total'
         $content | Should -Match 'No tests were analyzed'
         $content | Should -Match 'Failed Tests'


### PR DESCRIPTION
## Summary
Promotes the latest validated fork-first CI stabilization set to upstream `develop`.

### Included commits
- `cc9d7797` fix(ci): allowlist known password-protected vi-analyzer test errors
- `8e42b4cc` fix(vipc): pass FailOnMismatch as boolean switch
- `c773b33f` ci: pin source-test lanes to lv2020 runner labels
- `0cd4eb25` ci: run runner-cli in-place via dotnet dll

## Notes
- This PR is opened from fork branch `svelderrainruiz:promote/c1ed70d-upstream-refresh`.
- Upstream branch was recently force-updated; this PR re-establishes a deterministic promotion path from current validated fork content.