### PR TITLE
fix(build-lvlibp): make LabVIEW CLI port contract helper powershell-5 compatible

### DIFF
--- a/Tooling/support/GcliRunner.ps1
+++ b/Tooling/support/GcliRunner.ps1
@@ -1,8 +1,72 @@
-#Requires -Version 7.0
 <#
 .SYNOPSIS
     Helper for invoking g-cli while capturing stdout and stderr separately.
 #>
+
+function ConvertTo-NativeProcessArgumentString {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$Arguments
+    )
+
+    if ($Arguments.Count -eq 0) {
+        return ''
+    }
+
+    $formatted = foreach ($argument in $Arguments) {
+        if ($null -eq $argument) {
+            '""'
+            continue
+        }
+
+        $value = [string]$argument
+        if ($value.Length -eq 0) {
+            '""'
+            continue
+        }
+
+        if ($value -notmatch '[\s"]') {
+            $value
+            continue
+        }
+
+        # Match CreateProcess argument parsing rules for quoted values.
+        $builder = [System.Text.StringBuilder]::new()
+        $null = $builder.Append('"')
+        $backslashCount = 0
+
+        foreach ($character in $value.ToCharArray()) {
+            if ($character -eq '\') {
+                $backslashCount++
+                continue
+            }
+
+            if ($character -eq '"') {
+                $null = $builder.Append('\', ($backslashCount * 2) + 1)
+                $null = $builder.Append('"')
+                $backslashCount = 0
+                continue
+            }
+
+            if ($backslashCount -gt 0) {
+                $null = $builder.Append('\', $backslashCount)
+                $backslashCount = 0
+            }
+
+            $null = $builder.Append($character)
+        }
+
+        if ($backslashCount -gt 0) {
+            $null = $builder.Append('\', $backslashCount * 2)
+        }
+
+        $null = $builder.Append('"')
+        $builder.ToString()
+    }
+
+    return ($formatted -join ' ')
+}
 
 function Invoke-GCliCommand {
     param(
@@ -25,8 +89,13 @@ function Invoke-GCliCommand {
     $startInfo.UseShellExecute = $false
     $startInfo.CreateNoWindow = $true
 
-    foreach ($arg in $Arguments) {
-        $null = $startInfo.ArgumentList.Add($arg)
+    $hasArgumentList = $startInfo.PSObject.Properties.Match('ArgumentList').Count -gt 0
+    if ($hasArgumentList) {
+        foreach ($arg in $Arguments) {
+            $null = $startInfo.ArgumentList.Add($arg)
+        }
+    } else {
+        $startInfo.Arguments = ConvertTo-NativeProcessArgumentString -Arguments $Arguments
     }
 
     $process = [System.Diagnostics.Process]::new()
@@ -41,7 +110,12 @@ function Invoke-GCliCommand {
         if (-not $process.WaitForExit($TimeoutMs)) {
             $timedOut = $true
             try {
-                $process.Kill($true)
+                $killWithChildren = $process.GetType().GetMethod('Kill', [Type[]]@([bool]))
+                if ($null -ne $killWithChildren) {
+                    $process.Kill($true)
+                } else {
+                    $process.Kill()
+                }
             } catch {
                 Write-Verbose ("Failed to terminate g-cli process after timeout. {0}" -f $_.Exception.Message)
             }

--- a/Tooling/support/LabVIEWCliPortContract.ps1
+++ b/Tooling/support/LabVIEWCliPortContract.ps1
@@ -1,5 +1,3 @@
-#Requires -Version 7.0
-
 $ErrorActionPreference = 'Stop'
 
 function Resolve-LabVIEWCliPortContractRepoRoot {

--- a/Tooling/tests/LvExecutionYearFallbackContract.Tests.ps1
+++ b/Tooling/tests/LvExecutionYearFallbackContract.Tests.ps1
@@ -10,11 +10,13 @@ Describe 'LabVIEW execution-year fallback contract' {
         $script:invokeVipBuildPath = Join-Path $script:repoRoot 'Tooling\Invoke-VipBuild.ps1'
         $script:buildVipScriptPath = Join-Path $script:repoRoot '.github\actions\build-vip\build_vip.ps1'
         $script:labviewExeResolverPath = Join-Path $script:repoRoot 'Tooling\support\LabVIEWExecutablePath.ps1'
+        $script:labviewCliPortContractPath = Join-Path $script:repoRoot 'Tooling\support\LabVIEWCliPortContract.ps1'
 
         $script:pplBuildScriptContent = Get-Content -Path $script:pplBuildScriptPath -Raw
         $script:invokeVipBuildContent = Get-Content -Path $script:invokeVipBuildPath -Raw
         $script:buildVipScriptContent = Get-Content -Path $script:buildVipScriptPath -Raw
         $script:labviewExeResolverContent = Get-Content -Path $script:labviewExeResolverPath -Raw
+        $script:labviewCliPortContractContent = Get-Content -Path $script:labviewCliPortContractPath -Raw
     }
 
     It 'BuildProjectSpec accepts execution-year override and keeps source version contract' {
@@ -31,6 +33,7 @@ Describe 'LabVIEW execution-year fallback contract' {
         $script:pplBuildScriptContent | Should -Match '\$supportsHeadlessBuildSpec = \[int\]::TryParse\(\[string\]\$executionLabVIEWYear'
         $script:pplBuildScriptContent | Should -Match 'Invoke-CloseLabVIEWSafely -Version \$executionLabVIEWYear'
         $script:labviewExeResolverContent | Should -Not -Match '(?m)^\s*#Requires\s+-Version'
+        $script:labviewCliPortContractContent | Should -Not -Match '(?m)^\s*#Requires\s+-Version'
     }
 
     It 'Invoke-VipBuild forwards execution-year override to build_vip script' {

--- a/Tooling/tests/LvExecutionYearFallbackContract.Tests.ps1
+++ b/Tooling/tests/LvExecutionYearFallbackContract.Tests.ps1
@@ -11,12 +11,14 @@ Describe 'LabVIEW execution-year fallback contract' {
         $script:buildVipScriptPath = Join-Path $script:repoRoot '.github\actions\build-vip\build_vip.ps1'
         $script:labviewExeResolverPath = Join-Path $script:repoRoot 'Tooling\support\LabVIEWExecutablePath.ps1'
         $script:labviewCliPortContractPath = Join-Path $script:repoRoot 'Tooling\support\LabVIEWCliPortContract.ps1'
+        $script:gcliRunnerPath = Join-Path $script:repoRoot 'Tooling\support\GcliRunner.ps1'
 
         $script:pplBuildScriptContent = Get-Content -Path $script:pplBuildScriptPath -Raw
         $script:invokeVipBuildContent = Get-Content -Path $script:invokeVipBuildPath -Raw
         $script:buildVipScriptContent = Get-Content -Path $script:buildVipScriptPath -Raw
         $script:labviewExeResolverContent = Get-Content -Path $script:labviewExeResolverPath -Raw
         $script:labviewCliPortContractContent = Get-Content -Path $script:labviewCliPortContractPath -Raw
+        $script:gcliRunnerContent = Get-Content -Path $script:gcliRunnerPath -Raw
     }
 
     It 'BuildProjectSpec accepts execution-year override and keeps source version contract' {
@@ -53,5 +55,6 @@ Describe 'LabVIEW execution-year fallback contract' {
         $script:buildVipScriptContent | Should -Match '\$lvNumericMajor\s*=\s*\[int\]\$resolvedExecutionLabVIEWYear - 2000'
         $script:buildVipScriptContent | Should -Match 'VIPM target fallback applied'
         $script:buildVipScriptContent | Should -Match 'major-compatible target'
+        $script:gcliRunnerContent | Should -Not -Match '(?m)^\s*#Requires\s+-Version'
     }
 }


### PR DESCRIPTION
Remove file-scope version lock from Tooling/support/LabVIEWCliPortContract.ps1 so BuildProjectSpec can run under Windows PowerShell 5.1 in windows gate lanes. Add contract assertion in Tooling/tests/LvExecutionYearFallbackContract.Tests.ps1 to keep both LabVIEW helper scripts free of file-scope #Requires -Version directives.