### PR TITLE
Set .lvcontainer to 2026q1-windows

### DIFF
--- a/.lvcontainer
+++ b/.lvcontainer
@@ -1,1 +1,1 @@
-2026q1-linux
+2026q1-windows


### PR DESCRIPTION
## Summary\nSet the repository .lvcontainer contract tag from 2026q1-linux to 2026q1-windows.\n\n## Why\nAlign container selector with the Windows image lane contract used by downstream gate workflows.\n\n## Change\n- .lvcontainer: 2026q1-linux -> 2026q1-windows\n\n## Validation\n- File-only contract update; no code path changes.