### PR TITLE
runner-cli: add execution-year override for Windows gating

### DIFF
--- a/Tooling/runner-cli/RunnerCli.Tests/LabVIEWExecutionYearCompatibilityServiceTests.cs
+++ b/Tooling/runner-cli/RunnerCli.Tests/LabVIEWExecutionYearCompatibilityServiceTests.cs
@@ -5,6 +5,40 @@ namespace RunnerCli.Tests;
 public class LabVIEWExecutionYearCompatibilityServiceTests
 {
     [Fact]
+    public void Resolve_honors_execution_year_override_env_var()
+    {
+        using var repoFixture = CreateRepoFixture("20.0");
+        using var envOverride = new EnvironmentVariableOverride(
+            LabVIEWExecutionYearCompatibilityService.ExecutionYearOverrideEnvVar,
+            "2020");
+
+        var result = LabVIEWExecutionYearCompatibilityService.Resolve(
+            sourceLabviewVersion: "20.0",
+            repoRoot: repoFixture.RepoRoot,
+            commandLabel: "ppl build");
+
+        Assert.Equal("20.0", result.SourceVersion.Raw);
+        Assert.Equal("2020", result.SourceVersion.Year);
+        Assert.Equal("2020", result.ExecutionYear);
+        Assert.False(result.CompatMappingApplied);
+    }
+
+    [Fact]
+    public void Resolve_throws_on_invalid_execution_year_override_env_var()
+    {
+        using var repoFixture = CreateRepoFixture("20.0");
+        using var envOverride = new EnvironmentVariableOverride(
+            LabVIEWExecutionYearCompatibilityService.ExecutionYearOverrideEnvVar,
+            "twenty-twenty");
+
+        Assert.Throws<InvalidOperationException>(() =>
+            LabVIEWExecutionYearCompatibilityService.Resolve(
+                sourceLabviewVersion: "20.0",
+                repoRoot: repoFixture.RepoRoot,
+                commandLabel: "ppl build"));
+    }
+
+    [Fact]
     public void Resolve_maps_lv2020_source_to_lv2026_execution_year()
     {
         using var repoFixture = CreateRepoFixture("20.0");
@@ -80,6 +114,24 @@ public class LabVIEWExecutionYearCompatibilityServiceTests
             {
                 // Best-effort cleanup.
             }
+        }
+    }
+
+    private sealed class EnvironmentVariableOverride : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableOverride(string name, string? value)
+        {
+            _name = name;
+            _originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _originalValue);
         }
     }
 }

--- a/Tooling/runner-cli/RunnerCli/LabVIEWExecutionYearCompatibilityService.cs
+++ b/Tooling/runner-cli/RunnerCli/LabVIEWExecutionYearCompatibilityService.cs
@@ -10,6 +10,7 @@ public static class LabVIEWExecutionYearCompatibilityService
 {
     public const string SourceYearLv2020 = "2020";
     public const string FallbackExecutionYear = "2026";
+    public const string ExecutionYearOverrideEnvVar = "LVIE_RUNNERCLI_EXECUTION_LABVIEW_YEAR";
 
     public static LabVIEWExecutionYearResolution Resolve(
         string? sourceLabviewVersion,
@@ -22,15 +23,42 @@ public static class LabVIEWExecutionYearCompatibilityService
         }
 
         var sourceVersion = LabVIEWVersionService.GetVersionInfo(sourceLabviewVersion, repoRoot);
-        var compatMappingApplied = string.Equals(
-            sourceVersion.Year,
-            SourceYearLv2020,
-            StringComparison.Ordinal);
-        var executionYear = compatMappingApplied ? FallbackExecutionYear : sourceVersion.Year;
+        var executionYearOverride = Environment.GetEnvironmentVariable(ExecutionYearOverrideEnvVar)?.Trim();
+        var hasExecutionYearOverride = !string.IsNullOrWhiteSpace(executionYearOverride);
+        if (hasExecutionYearOverride &&
+            !System.Text.RegularExpressions.Regex.IsMatch(executionYearOverride!, @"^\d{4}$"))
+        {
+            throw new InvalidOperationException(
+                $"{ExecutionYearOverrideEnvVar} must be a 4-digit year. actual='{executionYearOverride}'.");
+        }
+
+        var compatMappingApplied = false;
+        var executionYear = sourceVersion.Year;
+        if (hasExecutionYearOverride)
+        {
+            executionYear = executionYearOverride!;
+            compatMappingApplied = !string.Equals(
+                sourceVersion.Year,
+                executionYear,
+                StringComparison.Ordinal);
+        }
+        else
+        {
+            compatMappingApplied = string.Equals(
+                sourceVersion.Year,
+                SourceYearLv2020,
+                StringComparison.Ordinal);
+            executionYear = compatMappingApplied ? FallbackExecutionYear : sourceVersion.Year;
+        }
 
         Console.Error.WriteLine(
             $"{commandLabel} LabVIEW source contract: raw={sourceVersion.Raw}; year={sourceVersion.Year}; minor={sourceVersion.MinorRevision}.");
-        if (compatMappingApplied)
+        if (hasExecutionYearOverride)
+        {
+            Console.Error.WriteLine(
+                $"{commandLabel} LabVIEW execution-year override applied via {ExecutionYearOverrideEnvVar}: source year {sourceVersion.Year} -> execution year {executionYear}.");
+        }
+        else if (compatMappingApplied)
         {
             Console.Error.WriteLine(
                 $"{commandLabel} LabVIEW execution-year compatibility mapping applied: source year {sourceVersion.Year} -> execution year {executionYear}.");


### PR DESCRIPTION
Ports commit b950be8 equivalent onto current upstream develop after .lvcontainer update.\n\nChanges:\n- add LVIE_RUNNERCLI_EXECUTION_LABVIEW_YEAR override path in LabVIEWExecutionYearCompatibilityService\n- add tests for override behavior and validation guardrails\n\nNo behavior change unless the environment variable is set.